### PR TITLE
Feature/#5 - 개별 주식을 선택하면 조회수가 증가한다.

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { typeormConfig } from '@/configs/typeorm.config';
+import { StockModule } from '@/stock/stock.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeormConfig)],
+  imports: [StockModule, TypeOrmModule.forRoot(typeormConfig)],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/packages/backend/src/stock/domain/stock.entity.ts
+++ b/packages/backend/src/stock/domain/stock.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity()
+export class Stock {
+  @PrimaryColumn({ name: 'stock_id' })
+  id: string;
+  @Column({ name: 'stock_name' })
+  name: string;
+  @Column()
+  views: number;
+
+  constructor(id: string, name: string, views?: number) {
+    this.id = id;
+    this.name = name;
+    this.views = views ?? 0;
+  }
+}

--- a/packages/backend/src/stock/stock.controller.ts
+++ b/packages/backend/src/stock/stock.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { StockService } from './stock.service';
+
+export type stockViewRequest = {
+  id: string;
+};
+
+@Controller('stock')
+export class StockController {
+  constructor(private readonly stockService: StockService) {}
+
+  @HttpCode(200)
+  @Post('/view')
+  async increaseStock(@Body() request: stockViewRequest): Promise<void> {
+    await this.stockService.increaseView(request.id);
+  }
+}

--- a/packages/backend/src/stock/stock.module.ts
+++ b/packages/backend/src/stock/stock.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Stock } from './domain/stock.entity';
+import { StockController } from './stock.controller';
+import { StockService } from './stock.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Stock])],
+  controllers: [StockController],
+  providers: [StockService],
+})
+export class StockModule {}

--- a/packages/backend/src/stock/stock.service.spec.ts
+++ b/packages/backend/src/stock/stock.service.spec.ts
@@ -1,0 +1,37 @@
+import { DataSource } from 'typeorm';
+import { StockService } from './stock.service';
+
+describe('StockService 테스트', () => {
+  test('주식의 조회수를 증가시킨다.', async () => {
+    const dataSource: Partial<DataSource> = {
+      transaction: jest.fn().mockImplementation(async (work) => {
+        const managerMock = {
+          exists: jest.fn().mockResolvedValue(true),
+          increment: jest.fn().mockResolvedValue({ id: 'A005930', views: 1 }),
+        };
+        return work(managerMock);
+      }),
+    };
+    const stockService = new StockService(dataSource as DataSource);
+
+    await stockService.increaseView('A005930');
+
+    expect(dataSource.transaction).toHaveBeenCalled();
+  });
+
+  test('존재하지 않는 주식의 조회수를 증가시키려 하면 예외가 발생한다.', async () => {
+    const dataSource: Partial<DataSource> = {
+      transaction: jest.fn().mockImplementation(async (work) => {
+        const managerMock = {
+          exists: jest.fn().mockResolvedValue(false),
+        };
+        return work(managerMock);
+      }),
+    };
+    const stockService = new StockService(dataSource as DataSource);
+
+    await expect(async () =>
+      stockService.increaseView('1'),
+    ).rejects.toThrowError('stock not found');
+  });
+});

--- a/packages/backend/src/stock/stock.service.ts
+++ b/packages/backend/src/stock/stock.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { Stock } from './domain/stock.entity';
+
+@Injectable()
+export class StockService {
+  constructor(private readonly datasource: DataSource) {}
+
+  async increaseView(stockId: string) {
+    await this.datasource.transaction(async (manager) => {
+      const isExists = await manager.exists(Stock, { where: { id: stockId } });
+      if (!isExists) {
+        throw new NotFoundException('stock not found');
+      }
+      return await manager.increment(Stock, { id: stockId }, 'views', 1);
+    });
+  }
+}


### PR DESCRIPTION
close #5 

## ✅ 작업 내용
- 주식 도메인 구현
- 주식 조회수 증가 API 구현

## 📸 스크린샷(FE만)

## 📌 이슈 사항
- stockService 단위테스트 구현 문제
   - `StockService`는 `Datasource`를 의존하게 되므로 가짜 `Datasource`를 만들어야한다.
   - 하지만 `transaction` 함수와 콜백으로 전달하는 `entitymanager`도 가짜 객체를 만들어야 함
   - `mockImplementation`으로 콜백 함수에 가짜 `entitymanager`를 전달하도록하여 문제 해결
   - 단 `datasource.manager.transaction`은 `manager`가 `readonly`라 가짜 `mock`을 넣을 수 없음
## 🟢 완료 조건
- 관련 로직 테스트 코드 작성
## ✍ 궁금한 점
- 일단 pr에 올린 엔티티 클래스는 undefined 에러 때문에 생성자를 만들도록 했습니다. 
- 엔티티 클래스 형식을 어떻게 할까요? 저는 아래처럼 `?`를 활용하고자 합니다!
```ts
@Entity({ name: 'users' })
export class User {
  @PrimaryGeneratedColumn()
  id?: number;

  @Column({ length: 50 })
  nickname?: string;

  @Column({ length: 50 })
  email?: string;

  @Column({ length: 5, default: 'user' })
  role: string = 'user';
}
```
## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
