### PR TITLE
chore: PR 시에 이슈 자동으로 close

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,0 +1,26 @@
+name: Close Related Issue on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev-be, dev-fe]
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close related issue
+        if: ${{ github.event.pull_request.merged == true }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUMBERS=$(echo "${{ github.event.pull_request.body }}" | grep -o -E '([cC]lose #[0-9]+)' | grep -o '[0-9]\+')
+
+          for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+            echo "Closing issue #$ISSUE_NUMBER"
+            curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+                 -H "Accept: application/vnd.github.v3+json" \
+                 https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER \
+                 -d '{"state": "closed"}'
+          done


### PR DESCRIPTION
close #142

## ✅ 작업 내용

GitHub Action을 이용해서 `dev-be`, `dev-fe` 브랜치로 merge 시에 `close #issue` 구문을 통해서 해당 이슈를 닫아주도록 했습니다. 

## ✍ 궁금한 점

## 😎 체크 사항

- [X] label 설정 확인
- [X] 브랜치 방향 확인