### PR TITLE
Feature/#15 실시간 주가 정보 제공 기능 구현

### DIFF
--- a/packages/backend/src/stock/domain/stockLiveData.entity.ts
+++ b/packages/backend/src/stock/domain/stockLiveData.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Stock } from './stock.entity';
+
+@Entity('stock_live_data')
+export class StockLiveData {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  current_price: number;
+
+  @Column({ type: 'decimal', precision: 5, scale: 2 })
+  change_rate: number;
+
+  @Column()
+  volume: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  high: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  low: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  open: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  previous_close: number;
+
+  @Column({ type: 'timestamp' })
+  updated_at: Date;
+
+  @OneToOne(() => Stock)
+  @JoinColumn({ name: 'stock_id' })
+  stock: Stock;
+}

--- a/packages/backend/src/stock/stock.gateway.ts
+++ b/packages/backend/src/stock/stock.gateway.ts
@@ -29,6 +29,18 @@ export class StockGateway {
     });
   }
 
+  handleDisconnectStock(
+    @MessageBody() stockId: string,
+    @ConnectedSocket() client: Socket,
+  ) {
+    client.leave(stockId);
+
+    client.emit('disconnectionSuccess', {
+      message: `Successfully disconnected to stock room: ${stockId}`,
+      stockId,
+    });
+  }
+
   onUpdateStock(
     stockId: string,
     price: number,

--- a/packages/backend/src/stock/stock.gateway.ts
+++ b/packages/backend/src/stock/stock.gateway.ts
@@ -17,11 +17,16 @@ export class StockGateway {
   constructor() {}
 
   @SubscribeMessage('connectStock')
-  handleJoinStockRoom(
+  handleConnectStock(
     @MessageBody() stockId: string,
     @ConnectedSocket() client: Socket,
   ) {
     client.join(stockId);
+
+    client.emit('connectionSuccess', {
+      message: `Successfully connected to stock room: ${stockId}`,
+      stockId,
+    });
   }
 
   onUpdateStock(

--- a/packages/backend/src/stock/stock.gateway.ts
+++ b/packages/backend/src/stock/stock.gateway.ts
@@ -22,7 +22,12 @@ export class StockGateway {
     client.join(stockId);
   }
 
-  onUpdateStock(stockId: string, price: number, change: number) {
-    this.server.to(stockId).emit('updateStock', price, change);
+  onUpdateStock(
+    stockId: string,
+    price: number,
+    change: number,
+    volume: number,
+  ) {
+    this.server.to(stockId).emit('updateStock', { price, change, volume });
   }
 }

--- a/packages/backend/src/stock/stock.gateway.ts
+++ b/packages/backend/src/stock/stock.gateway.ts
@@ -7,7 +7,9 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 
-@WebSocketGateway()
+@WebSocketGateway({
+  path: '/stock',
+})
 export class StockGateway {
   @WebSocketServer()
   server: Server;

--- a/packages/backend/src/stock/stock.module.ts
+++ b/packages/backend/src/stock/stock.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Stock } from './domain/stock.entity';
 import { StockController } from './stock.controller';
+import { StockGateway } from './stock.gateway';
 import { StockService } from './stock.service';
+import { StockLiveDataSubscriber } from './stockLiveData.subscriber';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Stock])],
   controllers: [StockController],
-  providers: [StockService],
+  providers: [StockService, StockGateway, StockLiveDataSubscriber],
 })
 export class StockModule {}

--- a/packages/backend/src/stock/stockLiveData.subscriber.ts
+++ b/packages/backend/src/stock/stockLiveData.subscriber.ts
@@ -1,0 +1,52 @@
+import { Inject } from '@nestjs/common';
+import {
+  EventSubscriber,
+  EntitySubscriberInterface,
+  UpdateEvent,
+} from 'typeorm';
+import { Logger } from 'winston';
+import { StockLiveData } from './domain/stockLiveData.entity';
+import { StockGateway } from './stock.gateway';
+
+@EventSubscriber()
+export class StockLiveDataSubscriber
+  implements EntitySubscriberInterface<StockLiveData>
+{
+  constructor(
+    private readonly stockGateway: StockGateway,
+    @Inject('winston') private readonly logger: Logger,
+  ) {}
+
+  listenTo() {
+    return StockLiveData;
+  }
+
+  async afterUpdate(event: UpdateEvent<StockLiveData>) {
+    try {
+      const updatedStockLiveData =
+        event.entity || (await this.loadUpdatedData(event));
+
+      if (updatedStockLiveData?.stock?.id) {
+        const { id: stockId } = updatedStockLiveData.stock;
+        const {
+          current_price: price,
+          change_rate: change,
+          volume: volume,
+        } = updatedStockLiveData;
+        this.stockGateway.onUpdateStock(stockId, price, change, volume);
+      } else {
+        this.logger.error(
+          `Stock ID missing for updated data : ${updatedStockLiveData?.id}`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(`Failed to handle afterUpdate event : ${error}`);
+    }
+  }
+
+  private async loadUpdatedData(event: UpdateEvent<StockLiveData>) {
+    return event.manager.findOne(StockLiveData, {
+      where: { id: event.databaseEntity.id },
+    });
+  }
+}


### PR DESCRIPTION
close #15 

## ✅ 작업 내용

- StockLiveData 엔티티 정의
- EntitySubscriber 정의
- afterUpdate 통해서 Entity 업데이트 시 소켓으로 데이터 전달
- 소켓 전달 정보 거래량 추가
- 클라이언트가 주식 정보에 입장 시에 메세지 전송
- 클라이언트 주식 연결 끊기 추가

## 📌 이슈 사항

- 로컬에서 MySQL이 맛이 가서 해결을 해야할 것 같습니다. 설치도 되고 터미널에서 사용도 되는데 로컬 환경 접속이 안 되네요. 포트 자체가 안 잡혀요...

## ✍ 궁금한 점

- 웹소켓의 경우 `WebSocketGateway`를 이용해서 `Swagger`를 통한 문서화가 어려운 데 가상의 컨트롤러로 `Swagger`를 쓸 지? 아니면 그냥 따로 문서화할 지?

## 😎 체크 사항

- [X] label 설정 확인
- [X] 브랜치 방향 확인
