### PR TITLE
Feature/#22 주식 차트 데이터 조회 기능 추가

### DIFF
--- a/packages/backend/src/stock/decorator/stockData.decorator.ts
+++ b/packages/backend/src/stock/decorator/stockData.decorator.ts
@@ -9,10 +9,10 @@ export function ApiGetStockData(summary: string, type: string) {
   return applyDecorators(
     ApiOperation({ summary }),
     ApiParam({
-      name: 'id',
-      type: Number,
+      name: 'stockId',
+      type: String,
       description: '주식 ID',
-      example: 1,
+      example: 'A005930',
     }),
     ApiQuery({
       name: 'lastStartTime',

--- a/packages/backend/src/stock/decorator/stockData.decorator.ts
+++ b/packages/backend/src/stock/decorator/stockData.decorator.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable max-lines-per-function */
+
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { StockDataResponse } from '../dto/stockData.response';
+
+export function ApiGetStockData(summary: string, type: string) {
+  return applyDecorators(
+    ApiOperation({ summary }),
+    ApiParam({
+      name: 'id',
+      type: Number,
+      description: '주식 ID',
+      example: 1,
+    }),
+    ApiQuery({
+      name: 'lastStartTime',
+      required: false,
+      description: '마지막 시작 시간 (ISO 8601 형식)',
+      example: '2024-04-01T00:00:00.000Z',
+      type: String,
+      format: 'date-time',
+    }),
+    ApiResponse({
+      status: 200,
+      description: `주식의 ${type} 단위 데이터 성공적으로 조회`,
+      type: StockDataResponse,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '주식 데이터가 존재하지 않음',
+    }),
+  );
+}

--- a/packages/backend/src/stock/domain/stockData.entity.ts
+++ b/packages/backend/src/stock/domain/stockData.entity.ts
@@ -3,8 +3,8 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
-  OneToOne,
   JoinColumn,
+  ManyToOne,
 } from 'typeorm';
 import { Stock } from './stock.entity';
 
@@ -30,7 +30,7 @@ abstract class StockData {
   @Column({ type: 'timestamp', name: 'start_time' })
   startTime: Date;
 
-  @OneToOne(() => Stock)
+  @ManyToOne(() => Stock)
   @JoinColumn({ name: 'stock_id' })
   stock: Stock;
 

--- a/packages/backend/src/stock/domain/stockData.entity.ts
+++ b/packages/backend/src/stock/domain/stockData.entity.ts
@@ -1,0 +1,161 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  OneToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Stock } from './stock.entity';
+
+@Entity('stock_minutely')
+export class StockMinutely {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  close: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  low: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  high: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  open: number;
+
+  @Column()
+  volume: number;
+
+  @Column({ type: 'timestamp' })
+  startTime: Date;
+
+  @OneToOne(() => Stock)
+  @JoinColumn({ name: 'stock_id' })
+  stock: Stock;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}
+
+@Entity('stock_daily')
+export class StockDaily {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  close: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  low: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  high: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  open: number;
+
+  @Column()
+  volume: number;
+
+  @Column({ type: 'timestamp' })
+  startTime: Date;
+
+  @OneToOne(() => Stock)
+  @JoinColumn({ name: 'stock_id' })
+  stock: Stock;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}
+@Entity('stock_weekly')
+export class StockWeekly {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  close: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  low: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  high: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  open: number;
+
+  @Column()
+  volume: number;
+
+  @Column({ type: 'timestamp' })
+  startTime: Date;
+
+  @OneToOne(() => Stock)
+  @JoinColumn({ name: 'stock_id' })
+  stock: Stock;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}
+@Entity('stock_monthly')
+export class StockMonthly {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  close: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  low: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  high: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  open: number;
+
+  @Column()
+  volume: number;
+
+  @Column({ type: 'timestamp' })
+  startTime: Date;
+
+  @OneToOne(() => Stock)
+  @JoinColumn({ name: 'stock_id' })
+  stock: Stock;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}
+@Entity('stock_yearly')
+export class StockYearly {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  close: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  low: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  high: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  open: number;
+
+  @Column()
+  volume: number;
+
+  @Column({ type: 'timestamp' })
+  startTime: Date;
+
+  @OneToOne(() => Stock)
+  @JoinColumn({ name: 'stock_id' })
+  stock: Stock;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/stock/domain/stockData.entity.ts
+++ b/packages/backend/src/stock/domain/stockData.entity.ts
@@ -25,17 +25,17 @@ export class StockMinutely {
   @Column({ type: 'decimal', precision: 15, scale: 2 })
   open: number;
 
-  @Column()
+  @Column({ type: 'bigint' })
   volume: number;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'timestamp', name: 'start_time' })
   startTime: Date;
 
   @OneToOne(() => Stock)
   @JoinColumn({ name: 'stock_id' })
   stock: Stock;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }
 
@@ -56,17 +56,17 @@ export class StockDaily {
   @Column({ type: 'decimal', precision: 15, scale: 2 })
   open: number;
 
-  @Column()
+  @Column({ type: 'bigint' })
   volume: number;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'timestamp', name: 'start_time' })
   startTime: Date;
 
   @OneToOne(() => Stock)
   @JoinColumn({ name: 'stock_id' })
   stock: Stock;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }
 @Entity('stock_weekly')
@@ -86,17 +86,17 @@ export class StockWeekly {
   @Column({ type: 'decimal', precision: 15, scale: 2 })
   open: number;
 
-  @Column()
+  @Column({ type: 'bigint' })
   volume: number;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'timestamp', name: 'start_time' })
   startTime: Date;
 
   @OneToOne(() => Stock)
   @JoinColumn({ name: 'stock_id' })
   stock: Stock;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }
 @Entity('stock_monthly')
@@ -116,17 +116,17 @@ export class StockMonthly {
   @Column({ type: 'decimal', precision: 15, scale: 2 })
   open: number;
 
-  @Column()
+  @Column({ type: 'bigint' })
   volume: number;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'timestamp', name: 'start_time' })
   startTime: Date;
 
   @OneToOne(() => Stock)
   @JoinColumn({ name: 'stock_id' })
   stock: Stock;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }
 @Entity('stock_yearly')
@@ -146,16 +146,16 @@ export class StockYearly {
   @Column({ type: 'decimal', precision: 15, scale: 2 })
   open: number;
 
-  @Column()
+  @Column({ type: 'bigint' })
   volume: number;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'timestamp', name: 'start_time' })
   startTime: Date;
 
   @OneToOne(() => Stock)
   @JoinColumn({ name: 'stock_id' })
   stock: Stock;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }

--- a/packages/backend/src/stock/domain/stockData.entity.ts
+++ b/packages/backend/src/stock/domain/stockData.entity.ts
@@ -8,8 +8,7 @@ import {
 } from 'typeorm';
 import { Stock } from './stock.entity';
 
-@Entity('stock_minutely')
-export class StockMinutely {
+abstract class StockData {
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -38,124 +37,15 @@ export class StockMinutely {
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }
+
+@Entity('stock_minutely')
+export class StockMinutely extends StockData {}
 
 @Entity('stock_daily')
-export class StockDaily {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  close: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  low: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  high: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  open: number;
-
-  @Column({ type: 'bigint' })
-  volume: number;
-
-  @Column({ type: 'timestamp', name: 'start_time' })
-  startTime: Date;
-
-  @OneToOne(() => Stock)
-  @JoinColumn({ name: 'stock_id' })
-  stock: Stock;
-
-  @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
-}
+export class StockDaily extends StockData {}
 @Entity('stock_weekly')
-export class StockWeekly {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  close: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  low: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  high: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  open: number;
-
-  @Column({ type: 'bigint' })
-  volume: number;
-
-  @Column({ type: 'timestamp', name: 'start_time' })
-  startTime: Date;
-
-  @OneToOne(() => Stock)
-  @JoinColumn({ name: 'stock_id' })
-  stock: Stock;
-
-  @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
-}
+export class StockWeekly extends StockData {}
 @Entity('stock_monthly')
-export class StockMonthly {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  close: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  low: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  high: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  open: number;
-
-  @Column({ type: 'bigint' })
-  volume: number;
-
-  @Column({ type: 'timestamp', name: 'start_time' })
-  startTime: Date;
-
-  @OneToOne(() => Stock)
-  @JoinColumn({ name: 'stock_id' })
-  stock: Stock;
-
-  @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
-}
+export class StockMonthly extends StockData {}
 @Entity('stock_yearly')
-export class StockYearly {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  close: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  low: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  high: number;
-
-  @Column({ type: 'decimal', precision: 15, scale: 2 })
-  open: number;
-
-  @Column({ type: 'bigint' })
-  volume: number;
-
-  @Column({ type: 'timestamp', name: 'start_time' })
-  startTime: Date;
-
-  @OneToOne(() => Stock)
-  @JoinColumn({ name: 'stock_id' })
-  stock: Stock;
-
-  @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
-}
+export class StockYearly extends StockData {}

--- a/packages/backend/src/stock/dto/stockData.response.ts
+++ b/packages/backend/src/stock/dto/stockData.response.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class PriceDto {
+  startTime: Date;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export class VolumeDto {
+  startTime: Date;
+  volume: number;
+  color: string;
+}
+
+export class StockDataResponse {
+  @ApiProperty({
+    description: '가격 데이터 배열 (날짜 오름차순)',
+  })
+  @Type(() => PriceDto)
+  priceDtoList: PriceDto[];
+
+  @ApiProperty({
+    description: '거래량 데이터 배열 (날짜 오름차순, 색 포함)',
+  })
+  @Type(() => VolumeDto)
+  volumeDtoList: VolumeDto[];
+
+  @ApiProperty({
+    description: '스크롤해서 불러올 수 있는 데이터가 더 존재하는지',
+  })
+  hasMore: boolean;
+}

--- a/packages/backend/src/stock/dto/stockData.response.ts
+++ b/packages/backend/src/stock/dto/stockData.response.ts
@@ -12,7 +12,6 @@ export class PriceDto {
 export class VolumeDto {
   startTime: Date;
   volume: number;
-  color: string;
 }
 
 export class StockDataResponse {

--- a/packages/backend/src/stock/dto/stockData.response.ts
+++ b/packages/backend/src/stock/dto/stockData.response.ts
@@ -2,33 +2,73 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 export class PriceDto {
+  @ApiProperty({
+    description: '시작 시간',
+    type: String,
+    format: 'date-time',
+    example: '2024-04-01T00:00:00.000Z',
+  })
   startTime: Date;
+
+  @ApiProperty({
+    description: '시가',
+    example: '121.00',
+  })
   open: number;
+
+  @ApiProperty({
+    description: '고가',
+    example: '125.00',
+  })
   high: number;
+
+  @ApiProperty({
+    description: '저가',
+    example: '120.00',
+  })
   low: number;
+
+  @ApiProperty({
+    description: '종가',
+    example: '123.45',
+  })
   close: number;
 }
 
 export class VolumeDto {
+  @ApiProperty({
+    description: '시작 시간',
+    type: String,
+    format: 'date-time',
+    example: '2024-04-01T00:00:00.000Z',
+  })
   startTime: Date;
+
+  @ApiProperty({
+    description: '거래량',
+    example: 1000,
+  })
   volume: number;
 }
 
 export class StockDataResponse {
   @ApiProperty({
     description: '가격 데이터 배열 (날짜 오름차순)',
+    type: [PriceDto],
   })
   @Type(() => PriceDto)
   priceDtoList: PriceDto[];
 
   @ApiProperty({
     description: '거래량 데이터 배열 (날짜 오름차순, 색 포함)',
+    type: [VolumeDto],
   })
   @Type(() => VolumeDto)
   volumeDtoList: VolumeDto[];
 
   @ApiProperty({
     description: '스크롤해서 불러올 수 있는 데이터가 더 존재하는지',
+    example: true,
   })
   hasMore: boolean;
 }

--- a/packages/backend/src/stock/stock.controller.ts
+++ b/packages/backend/src/stock/stock.controller.ts
@@ -8,8 +8,9 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
 import { ApiGetStockData } from './decorator/stockData.decorator';
+import { StockDetailResponse } from './dto/stockDetail.response';
 import { StockService } from './stock.service';
 import {
   StockDataDailyService,
@@ -18,6 +19,7 @@ import {
   StockDataWeeklyService,
   StockDataYearlyService,
 } from './stockData.service';
+import { StockDetailService } from './stockDetail.service';
 import { StockViewsResponse } from '@/stock/dto/stock.Response';
 import { StockViewRequest } from '@/stock/dto/stockView.request';
 import {
@@ -35,6 +37,7 @@ export class StockController {
     private readonly stockDataWeeklyService: StockDataWeeklyService,
     private readonly stockDataMonthlyService: StockDataMonthlyService,
     private readonly stockDataYearlyService: StockDataYearlyService,
+    private readonly stockDetailService: StockDetailService,
   ) {}
 
   @HttpCode(200)
@@ -160,5 +163,21 @@ export class StockController {
       stockId,
       lastStartTime,
     );
+  }
+
+  @ApiOperation({
+    summary: '주식 상세 정보 조회 API',
+    description: '시가 총액, EPS, PER, 52주 최고가, 52주 최저가를 조회합니다',
+  })
+  @ApiOkResponse({
+    description: '주식 상세 정보 조회 성공',
+    type: StockDetailResponse,
+  })
+  @ApiParam({ name: 'stockId', required: true, description: '주식 ID' })
+  @Get(':stockId/detail')
+  async getStockDetail(
+    @Param('stockId') stockId: string,
+  ): Promise<StockDetailResponse> {
+    return await this.stockDetailService.getStockDetailByStockId(stockId);
   }
 }

--- a/packages/backend/src/stock/stock.controller.ts
+++ b/packages/backend/src/stock/stock.controller.ts
@@ -11,7 +11,13 @@ import {
 import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { ApiGetStockData } from './decorator/stockData.decorator';
 import { StockService } from './stock.service';
-import { StockDataMinutelyService } from './stockData.service';
+import {
+  StockDataDailyService,
+  StockDataMinutelyService,
+  StockDataMonthlyService,
+  StockDataWeeklyService,
+  StockDataYearlyService,
+} from './stockData.service';
 import { StockViewsResponse } from '@/stock/dto/stock.Response';
 import { StockViewRequest } from '@/stock/dto/stockView.request';
 import {
@@ -25,6 +31,10 @@ export class StockController {
   constructor(
     private readonly stockService: StockService,
     private readonly stockDataMinutelyService: StockDataMinutelyService,
+    private readonly stockDataDailyService: StockDataDailyService,
+    private readonly stockDataWeeklyService: StockDataWeeklyService,
+    private readonly stockDataMonthlyService: StockDataMonthlyService,
+    private readonly stockDataYearlyService: StockDataYearlyService,
   ) {}
 
   @HttpCode(200)
@@ -102,6 +112,51 @@ export class StockController {
     @Query() lastStartTime?: string,
   ) {
     return this.stockDataMinutelyService.getStockDataMinutely(
+      stockId,
+      lastStartTime,
+    );
+  }
+
+  @Get(':stockId/daily')
+  @ApiGetStockData('주식 일 단위 데이터 조회 API', '일')
+  async getStockDataDaily(
+    @Param('stockId') stockId: string,
+    @Query() lastStartTime?: string,
+  ) {
+    return this.stockDataDailyService.getStockDataDaily(stockId, lastStartTime);
+  }
+
+  @Get(':stockId/weekly')
+  @ApiGetStockData('주식 주 단위 데이터 조회 API', '주')
+  async getStockDataWeekly(
+    @Param('stockId') stockId: string,
+    @Query() lastStartTime?: string,
+  ) {
+    return this.stockDataWeeklyService.getStockDataWeekly(
+      stockId,
+      lastStartTime,
+    );
+  }
+
+  @Get(':stockId/mothly')
+  @ApiGetStockData('주식 월 단위 데이터 조회 API', '월')
+  async getStockDataMonthly(
+    @Param('stockId') stockId: string,
+    @Query() lastStartTime?: string,
+  ) {
+    return this.stockDataMonthlyService.getStockDataMonthly(
+      stockId,
+      lastStartTime,
+    );
+  }
+
+  @Get(':stockId/yearly')
+  @ApiGetStockData('주식 연 단위 데이터 조회 API', '연')
+  async getStockDataYearly(
+    @Param('stockId') stockId: string,
+    @Query() lastStartTime?: string,
+  ) {
+    return this.stockDataYearlyService.getStockDataYearly(
       stockId,
       lastStartTime,
     );

--- a/packages/backend/src/stock/stock.controller.ts
+++ b/packages/backend/src/stock/stock.controller.ts
@@ -1,6 +1,17 @@
-import { Body, Controller, Delete, HttpCode, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { ApiGetStockData } from './decorator/stockData.decorator';
 import { StockService } from './stock.service';
+import { StockDataMinutelyService } from './stockData.service';
 import { StockViewsResponse } from '@/stock/dto/stock.Response';
 import { StockViewRequest } from '@/stock/dto/stockView.request';
 import {
@@ -11,7 +22,10 @@ import { UserStockResponse } from '@/stock/dto/userStock.response';
 
 @Controller('stock')
 export class StockController {
-  constructor(private readonly stockService: StockService) {}
+  constructor(
+    private readonly stockService: StockService,
+    private readonly stockDataMinutelyService: StockDataMinutelyService,
+  ) {}
 
   @HttpCode(200)
   @Post('/view')
@@ -78,6 +92,18 @@ export class StockController {
     return new UserStockResponse(
       request.userStockId,
       '사용자 소유 주식을 삭제했습니다.',
+    );
+  }
+
+  @Get(':stockId/minutely')
+  @ApiGetStockData('주식 분 단위 데이터 조회 API', '분')
+  async getStockDataMinutely(
+    @Param('stockId') stockId: string,
+    @Query() lastStartTime?: string,
+  ) {
+    return this.stockDataMinutelyService.getStockDataMinutely(
+      stockId,
+      lastStartTime,
     );
   }
 }

--- a/packages/backend/src/stock/stock.controller.ts
+++ b/packages/backend/src/stock/stock.controller.ts
@@ -109,7 +109,7 @@ export class StockController {
   @ApiGetStockData('주식 분 단위 데이터 조회 API', '분')
   async getStockDataMinutely(
     @Param('stockId') stockId: string,
-    @Query() lastStartTime?: string,
+    @Query('lastStartTime') lastStartTime?: string,
   ) {
     return this.stockDataMinutelyService.getStockDataMinutely(
       stockId,
@@ -121,7 +121,7 @@ export class StockController {
   @ApiGetStockData('주식 일 단위 데이터 조회 API', '일')
   async getStockDataDaily(
     @Param('stockId') stockId: string,
-    @Query() lastStartTime?: string,
+    @Query('lastStartTime') lastStartTime?: string,
   ) {
     return this.stockDataDailyService.getStockDataDaily(stockId, lastStartTime);
   }
@@ -130,7 +130,7 @@ export class StockController {
   @ApiGetStockData('주식 주 단위 데이터 조회 API', '주')
   async getStockDataWeekly(
     @Param('stockId') stockId: string,
-    @Query() lastStartTime?: string,
+    @Query('lastStartTime') lastStartTime?: string,
   ) {
     return this.stockDataWeeklyService.getStockDataWeekly(
       stockId,
@@ -142,7 +142,7 @@ export class StockController {
   @ApiGetStockData('주식 월 단위 데이터 조회 API', '월')
   async getStockDataMonthly(
     @Param('stockId') stockId: string,
-    @Query() lastStartTime?: string,
+    @Query('lastStartTime') lastStartTime?: string,
   ) {
     return this.stockDataMonthlyService.getStockDataMonthly(
       stockId,
@@ -154,7 +154,7 @@ export class StockController {
   @ApiGetStockData('주식 연 단위 데이터 조회 API', '연')
   async getStockDataYearly(
     @Param('stockId') stockId: string,
-    @Query() lastStartTime?: string,
+    @Query('lastStartTime') lastStartTime?: string,
   ) {
     return this.stockDataYearlyService.getStockDataYearly(
       stockId,

--- a/packages/backend/src/stock/stock.gateway.ts
+++ b/packages/backend/src/stock/stock.gateway.ts
@@ -8,7 +8,7 @@ import {
 import { Server, Socket } from 'socket.io';
 
 @WebSocketGateway({
-  path: '/realtimeStock',
+  namespace: '/stock/realtime',
 })
 export class StockGateway {
   @WebSocketServer()

--- a/packages/backend/src/stock/stock.gateway.ts
+++ b/packages/backend/src/stock/stock.gateway.ts
@@ -8,7 +8,7 @@ import {
 import { Server, Socket } from 'socket.io';
 
 @WebSocketGateway({
-  path: '/stock',
+  path: '/realtimeStock',
 })
 export class StockGateway {
   @WebSocketServer()

--- a/packages/backend/src/stock/stock.module.ts
+++ b/packages/backend/src/stock/stock.module.ts
@@ -1,14 +1,50 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Stock } from './domain/stock.entity';
+import {
+  StockDaily,
+  StockMinutely,
+  StockMonthly,
+  StockWeekly,
+  StockYearly,
+} from './domain/stockData.entity';
+import { StockLiveData } from './domain/stockLiveData.entity';
 import { StockController } from './stock.controller';
 import { StockGateway } from './stock.gateway';
 import { StockService } from './stock.service';
+import {
+  StockDataDailyService,
+  StockDataMinutelyService,
+  StockDataMonthlyService,
+  StockDataService,
+  StockDataWeeklyService,
+  StockDataYearlyService,
+} from './stockData.service';
 import { StockLiveDataSubscriber } from './stockLiveData.subscriber';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Stock])],
+  imports: [
+    TypeOrmModule.forFeature([
+      Stock,
+      StockMinutely,
+      StockDaily,
+      StockWeekly,
+      StockMonthly,
+      StockYearly,
+      StockLiveData,
+    ]),
+  ],
   controllers: [StockController],
-  providers: [StockService, StockGateway, StockLiveDataSubscriber],
+  providers: [
+    StockService,
+    StockGateway,
+    StockLiveDataSubscriber,
+    StockDataService,
+    StockDataDailyService,
+    StockDataMinutelyService,
+    StockDataWeeklyService,
+    StockDataYearlyService,
+    StockDataMonthlyService,
+  ],
 })
 export class StockModule {}

--- a/packages/backend/src/stock/stock.module.ts
+++ b/packages/backend/src/stock/stock.module.ts
@@ -8,6 +8,7 @@ import {
   StockWeekly,
   StockYearly,
 } from './domain/stockData.entity';
+import { StockDetail } from './domain/stockDetail.entity';
 import { StockLiveData } from './domain/stockLiveData.entity';
 import { StockController } from './stock.controller';
 import { StockGateway } from './stock.gateway';
@@ -20,6 +21,7 @@ import {
   StockDataWeeklyService,
   StockDataYearlyService,
 } from './stockData.service';
+import { StockDetailService } from './stockDetail.service';
 import { StockLiveDataSubscriber } from './stockLiveData.subscriber';
 
 @Module({
@@ -32,6 +34,7 @@ import { StockLiveDataSubscriber } from './stockLiveData.subscriber';
       StockMonthly,
       StockYearly,
       StockLiveData,
+      StockDetail,
     ]),
   ],
   controllers: [StockController],
@@ -45,6 +48,7 @@ import { StockLiveDataSubscriber } from './stockLiveData.subscriber';
     StockDataWeeklyService,
     StockDataYearlyService,
     StockDataMonthlyService,
+    StockDetailService,
   ],
 })
 export class StockModule {}

--- a/packages/backend/src/stock/stockData.service.spec.ts
+++ b/packages/backend/src/stock/stockData.service.spec.ts
@@ -1,0 +1,491 @@
+/* eslint-disable max-lines-per-function */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { plainToInstance } from 'class-transformer';
+import { DataSource, EntityManager, SelectQueryBuilder } from 'typeorm';
+import { Stock } from './domain/stock.entity';
+import {
+  StockMinutely,
+  StockDaily,
+  StockWeekly,
+  StockMonthly,
+  StockYearly,
+} from './domain/stockData.entity';
+import {
+  StockDataResponse,
+  PriceDto,
+  VolumeDto,
+} from './dto/stockData.response';
+import { StockDataService } from './stockData.service';
+
+// Mock DataSource와 EntityManager 생성 함수
+export function createDataSourceMock(
+  managerMock: Partial<EntityManager>,
+): Partial<DataSource> {
+  return {
+    manager: {
+      ...managerMock,
+      transaction: jest.fn().mockImplementation(async (work) => {
+        return work(managerMock as EntityManager);
+      }),
+    } as any, // TypeScript 오류를 피하기 위해 any로 캐스팅
+  };
+}
+
+// QueryBuilder 모킹을 위한 헬퍼 함수
+const createQueryBuilderMock = (
+  getManyResult: any[] = [],
+  throwError: boolean = false,
+): Partial<SelectQueryBuilder<any>> => {
+  return {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockImplementation(() => {
+      if (throwError) {
+        return Promise.reject(new Error('Query error'));
+      }
+      return Promise.resolve(getManyResult);
+    }),
+  };
+};
+
+describe('StockDataService', () => {
+  const stockId = 'A005930';
+  let dataSource: Partial<DataSource>;
+  let stockDataService: StockDataService;
+  let managerMock: any;
+
+  beforeEach(() => {
+    managerMock = {
+      createQueryBuilder: jest.fn(),
+      // 필요한 다른 메서드들도 여기에 추가할 수 있습니다.
+    };
+    dataSource = createDataSourceMock(managerMock);
+    stockDataService = new StockDataService(dataSource as DataSource);
+  });
+
+  describe('getPaginated', () => {
+    const PAGE_SIZE = 100;
+
+    it('주식 데이터를 페이지네이션하여 가져옵니다. hasMore=true', async () => {
+      const mockData: any[] = Array.from({ length: PAGE_SIZE + 1 }, (_, i) => ({
+        id: i,
+        close: 100 + i,
+        low: 90 + i,
+        high: 110 + i,
+        open: 95 + i,
+        volume: 1000 + i * 10,
+        startTime: new Date(
+          `2023-11-${(10 + (i % 20)).toString().padStart(2, '0')}`,
+        ),
+        stock: { id: stockId } as Stock,
+        createdAt: new Date(),
+      }));
+
+      const queryBuilderMock = createQueryBuilderMock(mockData);
+      (managerMock.createQueryBuilder as jest.Mock).mockReturnValue(
+        queryBuilderMock,
+      );
+
+      const response: StockDataResponse = await stockDataService.getPaginated(
+        StockMinutely,
+        stockId,
+      );
+
+      expect(managerMock.createQueryBuilder).toHaveBeenCalledWith(
+        StockMinutely,
+        'entity',
+      );
+      expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith(
+        'entity.stock',
+        'stock',
+      );
+      expect(queryBuilderMock.where).toHaveBeenCalledWith(
+        'entity.stock_id = :stockId',
+        { stockId },
+      );
+      expect(queryBuilderMock.orderBy).toHaveBeenCalledWith(
+        'entity.startTime',
+        'DESC',
+      );
+      expect(queryBuilderMock.take).toHaveBeenCalledWith(PAGE_SIZE + 1);
+      expect(response.hasMore).toBe(true);
+      expect(response.priceDtoList).toHaveLength(PAGE_SIZE);
+      expect(response.volumeDtoList).toHaveLength(PAGE_SIZE);
+    });
+
+    it('주식 데이터를 페이지네이션하여 가져옵니다. hasMore=false', async () => {
+      const mockData: any[] = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+        id: i,
+        close: 100 + i,
+        low: 90 + i,
+        high: 110 + i,
+        open: 95 + i,
+        volume: 1000 + i * 10,
+        startTime: new Date(
+          `2023-11-${(10 + (i % 20)).toString().padStart(2, '0')}`,
+        ),
+        stock: { id: stockId } as Stock,
+        createdAt: new Date(),
+      }));
+
+      const queryBuilderMock = createQueryBuilderMock(mockData);
+      (managerMock.createQueryBuilder as jest.Mock).mockReturnValue(
+        queryBuilderMock,
+      );
+
+      const response: StockDataResponse = await stockDataService.getPaginated(
+        StockMinutely,
+        stockId,
+      );
+
+      expect(response.hasMore).toBe(false);
+      expect(response.priceDtoList).toHaveLength(PAGE_SIZE);
+      expect(response.volumeDtoList).toHaveLength(PAGE_SIZE);
+    });
+
+    it('lastStartTime을 사용해 이전 데이터까지 페이지네이션 가져오기', async () => {
+      const lastStartTime = '2023-11-15';
+      const mockData: any[] = Array.from({ length: 50 }, (_, i) => ({
+        id: i,
+        close: 100 + i,
+        low: 90 + i,
+        high: 110 + i,
+        open: 95 + i,
+        volume: 1000 + i * 10,
+        startTime: new Date(
+          `2023-11-${(15 - (i % 15)).toString().padStart(2, '0')}`,
+        ),
+        stock: { id: stockId } as Stock,
+        createdAt: new Date(),
+      }));
+
+      const queryBuilderMock = createQueryBuilderMock(mockData);
+      (managerMock.createQueryBuilder as jest.Mock).mockReturnValue(
+        queryBuilderMock,
+      );
+
+      const response: StockDataResponse = await stockDataService.getPaginated(
+        StockMinutely,
+        stockId,
+        lastStartTime,
+      );
+
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith(
+        'entity.startTime < :lastStartTime',
+        { lastStartTime },
+      );
+      expect(response.hasMore).toBe(false);
+      expect(response.priceDtoList).toHaveLength(50);
+      expect(response.volumeDtoList).toHaveLength(50);
+    });
+
+    it('쿼리에서 예외가 발생하면 예외를 던집니다.', async () => {
+      const queryBuilderMock = createQueryBuilderMock([], true);
+      (managerMock.createQueryBuilder as jest.Mock).mockReturnValue(
+        queryBuilderMock,
+      );
+
+      await expect(
+        stockDataService.getPaginated(StockMinutely, stockId),
+      ).rejects.toThrow('Query error');
+    });
+  });
+
+  describe('mapResultListToPriceDtoList', () => {
+    it('StockData 목록을 PriceDto 목록으로 매핑합니다.', () => {
+      const resultList = [
+        {
+          id: 2,
+          startTime: new Date('2023-11-11T00:00:00Z'),
+          open: 105,
+          close: 115,
+          high: 120,
+          low: 100,
+          volume: 600,
+          stock: { id: stockId } as Stock,
+          createdAt: new Date(),
+        },
+        {
+          id: 1,
+          startTime: new Date('2023-11-10T00:00:00Z'),
+          open: 100,
+          close: 110,
+          high: 115,
+          low: 95,
+          volume: 500,
+          stock: { id: stockId } as Stock,
+          createdAt: new Date(),
+        },
+      ];
+
+      const priceDtoList: PriceDto[] =
+        stockDataService.mapResultListToPriceDtoList(resultList);
+
+      expect(priceDtoList).toEqual([
+        {
+          startTime: new Date('2023-11-10T00:00:00Z'),
+          open: 100,
+          close: 110,
+          high: 115,
+          low: 95,
+        },
+        {
+          startTime: new Date('2023-11-11T00:00:00Z'),
+          open: 105,
+          close: 115,
+          high: 120,
+          low: 100,
+        },
+      ]);
+    });
+  });
+
+  describe('mapResultListToVolumeDtoList', () => {
+    it('StockData 목록을 VolumeDto 목록으로 매핑합니다.', () => {
+      const resultList = [
+        {
+          id: 3,
+          startTime: new Date('2023-11-12T00:00:00Z'),
+          close: 110,
+          low: 95,
+          high: 125,
+          open: 115,
+          volume: 550,
+          stock: { id: stockId } as Stock,
+          createdAt: new Date(),
+        },
+        {
+          id: 2,
+          startTime: new Date('2023-11-11T00:00:00Z'),
+          close: 105,
+          low: 100,
+          high: 120,
+          open: 115,
+          volume: 600,
+          stock: { id: stockId } as Stock,
+          createdAt: new Date(),
+        },
+        {
+          id: 1,
+          startTime: new Date('2023-11-10T00:00:00Z'),
+          close: 100,
+          low: 90,
+          high: 110,
+          open: 95,
+          volume: 500,
+          stock: { id: stockId } as Stock,
+          createdAt: new Date(),
+        },
+      ];
+
+      const volumeDtoList: VolumeDto[] =
+        stockDataService.mapResultListToVolumeDtoList(resultList);
+
+      expect(volumeDtoList).toEqual([
+        {
+          startTime: new Date('2023-11-10T00:00:00Z'),
+          volume: 500,
+        },
+
+        {
+          startTime: new Date('2023-11-11T00:00:00Z'),
+          volume: 600,
+        },
+        {
+          startTime: new Date('2023-11-12T00:00:00Z'),
+          volume: 550,
+        },
+      ]);
+    });
+  });
+
+  describe('createStockDataResponse', () => {
+    it('PriceDto와 VolumeDto 목록을 포함한 StockDataResponse 객체를 생성합니다.', () => {
+      const priceDtoList: PriceDto[] = [
+        {
+          startTime: new Date('2023-11-11T00:00:00Z'),
+          open: 105,
+          close: 115,
+          high: 120,
+          low: 100,
+        },
+        {
+          startTime: new Date('2023-11-10T00:00:00Z'),
+          open: 100,
+          close: 110,
+          high: 115,
+          low: 95,
+        },
+      ];
+
+      const volumeDtoList: VolumeDto[] = [
+        {
+          startTime: new Date('2023-11-12T00:00:00Z'),
+          volume: 550,
+        },
+        {
+          startTime: new Date('2023-11-11T00:00:00Z'),
+          volume: 600,
+        },
+        {
+          startTime: new Date('2023-11-10T00:00:00Z'),
+          volume: 500,
+        },
+      ];
+
+      const response: StockDataResponse =
+        stockDataService.createStockDataResponse(
+          priceDtoList,
+          volumeDtoList,
+          true,
+        );
+
+      expect(response).toHaveProperty('priceDtoList');
+      expect(response).toHaveProperty('volumeDtoList');
+      expect(response.hasMore).toBe(true);
+      expect(response.priceDtoList).toEqual(
+        plainToInstance(PriceDto, priceDtoList),
+      );
+      expect(response.volumeDtoList).toEqual(
+        plainToInstance(VolumeDto, volumeDtoList),
+      );
+    });
+  });
+});
+
+class StockDataMinutelyService extends StockDataService {
+  async getStockDataMinutely(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    return await this.getPaginated(StockMinutely, stock_id, lastStartTime);
+  }
+}
+
+class StockDataDailyService extends StockDataService {
+  async getStockDataDaily(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    return await this.getPaginated(StockDaily, stock_id, lastStartTime);
+  }
+}
+
+class StockDataWeeklyService extends StockDataService {
+  async getStockDataWeekly(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    return await this.getPaginated(StockWeekly, stock_id, lastStartTime);
+  }
+}
+
+class StockDataMonthlyService extends StockDataService {
+  async getStockDataMonthly(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    return await this.getPaginated(StockMonthly, stock_id, lastStartTime);
+  }
+}
+
+class StockDataYearlyService extends StockDataService {
+  async getStockDataYearly(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    return await this.getPaginated(StockYearly, stock_id, lastStartTime);
+  }
+}
+
+describe('StockDataService 파생 클래스 테스트', () => {
+  const stockId = 'A005930';
+  let dataSource: Partial<DataSource>;
+  let managerMock: any;
+
+  beforeEach(() => {
+    managerMock = {
+      createQueryBuilder: jest.fn(),
+      // 필요한 다른 메서드들도 여기에 추가할 수 있습니다.
+    };
+    dataSource = createDataSourceMock(managerMock);
+  });
+
+  const testDerivedService = (
+    ServiceClass: any,
+    EntityClass: any,
+    methodName: string,
+  ) => {
+    describe(`${ServiceClass.name}`, () => {
+      let service: any;
+
+      beforeEach(() => {
+        service = new ServiceClass(dataSource as DataSource);
+      });
+
+      it(`${methodName} 메서드가 getPaginated를 호출하고 올바른 엔티티를 전달합니다.`, async () => {
+        const mockResponse: StockDataResponse = {
+          priceDtoList: [],
+          volumeDtoList: [],
+          hasMore: false,
+        };
+
+        const getPaginatedSpy = jest
+          .spyOn(StockDataService.prototype, 'getPaginated')
+          .mockResolvedValue(mockResponse);
+
+        const response = await service[methodName](stockId);
+
+        expect(getPaginatedSpy).toHaveBeenCalledWith(
+          EntityClass,
+          stockId,
+          undefined,
+        );
+        expect(response).toBe(mockResponse);
+
+        getPaginatedSpy.mockRestore();
+      });
+
+      it(`${methodName} 메서드에 lastStartTime을 전달합니다.`, async () => {
+        const lastStartTime = '2023-11-15';
+        const mockResponse: StockDataResponse = {
+          priceDtoList: [],
+          volumeDtoList: [],
+          hasMore: false,
+        };
+
+        const getPaginatedSpy = jest
+          .spyOn(StockDataService.prototype, 'getPaginated')
+          .mockResolvedValue(mockResponse);
+
+        const response = await service[methodName](stockId, lastStartTime);
+
+        expect(getPaginatedSpy).toHaveBeenCalledWith(
+          EntityClass,
+          stockId,
+          lastStartTime,
+        );
+        expect(response).toBe(mockResponse);
+
+        getPaginatedSpy.mockRestore();
+      });
+    });
+  };
+
+  testDerivedService(
+    StockDataMinutelyService,
+    StockMinutely,
+    'getStockDataMinutely',
+  );
+  testDerivedService(StockDataDailyService, StockDaily, 'getStockDataDaily');
+  testDerivedService(StockDataWeeklyService, StockWeekly, 'getStockDataWeekly');
+  testDerivedService(
+    StockDataMonthlyService,
+    StockMonthly,
+    'getStockDataMonthly',
+  );
+  testDerivedService(StockDataYearlyService, StockYearly, 'getStockDataYearly');
+});

--- a/packages/backend/src/stock/stockData.service.ts
+++ b/packages/backend/src/stock/stockData.service.ts
@@ -42,7 +42,6 @@ export class StockDataService {
     return await this.dataSource.manager.transaction(async (manager) => {
       const queryBuilder = manager
         .createQueryBuilder(entity, 'entity')
-        .leftJoinAndSelect('entity.stock', 'stock')
         .where('entity.stock_id = :stockId', { stockId: stock_id })
         .orderBy('entity.startTime', 'DESC')
         .take(this.PAGE_SIZE + 1);

--- a/packages/backend/src/stock/stockData.service.ts
+++ b/packages/backend/src/stock/stockData.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
-import { DataSource } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 import { Stock } from './domain/stock.entity';
 import {
   StockMinutely,
@@ -40,7 +40,7 @@ export class StockDataService {
     lastStartTime?: string,
   ): Promise<StockDataResponse> {
     return await this.dataSource.manager.transaction(async (manager) => {
-      if (!(await manager.exists(Stock, { where: { id: stock_id } })))
+      if (!(await this.isStockExist(stock_id, manager)))
         throw new NotFoundException('stock not found');
 
       const queryBuilder = manager
@@ -63,6 +63,10 @@ export class StockDataService {
 
       return this.createStockDataResponse(priceDtoList, volumeDtoList, hasMore);
     });
+  }
+
+  async isStockExist(stockId: string, manager: EntityManager) {
+    return await manager.exists(Stock, { where: { id: stockId } });
   }
 
   mapResultListToPriceDtoList(resultList: StockData[]): PriceDto[] {

--- a/packages/backend/src/stock/stockData.service.ts
+++ b/packages/backend/src/stock/stockData.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { DataSource } from 'typeorm';
 import { Stock } from './domain/stock.entity';
@@ -40,6 +40,9 @@ export class StockDataService {
     lastStartTime?: string,
   ): Promise<StockDataResponse> {
     return await this.dataSource.manager.transaction(async (manager) => {
+      if (!(await manager.exists(Stock, { where: { id: stock_id } })))
+        throw new NotFoundException('stock not found');
+
       const queryBuilder = manager
         .createQueryBuilder(entity, 'entity')
         .where('entity.stock_id = :stockId', { stockId: stock_id })

--- a/packages/backend/src/stock/stockData.service.ts
+++ b/packages/backend/src/stock/stockData.service.ts
@@ -1,0 +1,198 @@
+import { Injectable } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { DataSource } from 'typeorm';
+import { Stock } from './domain/stock.entity';
+import {
+  StockMinutely,
+  StockDaily,
+  StockMonthly,
+  StockWeekly,
+  StockYearly,
+} from './domain/stockData.entity';
+import {
+  PriceDto,
+  StockDataResponse,
+  VolumeDto,
+} from './dto/stockData.response';
+
+type StockData = {
+  id: number;
+  close: number;
+  low: number;
+  high: number;
+  open: number;
+  volume: number;
+  startTime: Date;
+  stock: Stock;
+  createdAt: Date;
+};
+
+@Injectable()
+export class StockDataService {
+  protected readonly PAGE_SIZE = 100;
+  protected readonly DEFAULT_COLOR = 'red';
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  async getPaginated(
+    entity: new () => StockData,
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    return await this.dataSource.manager.transaction(async (manager) => {
+      const queryBuilder = manager
+        .createQueryBuilder(entity, 'entity')
+        .leftJoinAndSelect('entity.stock', 'stock')
+        .where('entity.stock_id = :stockId', { stockId: stock_id })
+        .orderBy('entity.startTime', 'DESC')
+        .take(this.PAGE_SIZE + 1);
+
+      if (lastStartTime)
+        queryBuilder.andWhere('entity.startTime < :lastStartTime', {
+          lastStartTime: lastStartTime,
+        });
+
+      const resultList = await queryBuilder.getMany();
+
+      const hasMore = resultList.length > this.PAGE_SIZE;
+      if (hasMore) resultList.pop();
+      const priceDtoList = this.mapResultListToPriceDtoList(resultList);
+      const volumeDtoList = this.mapResultListToVolumeDtoList(resultList);
+
+      return this.createStockDataResponse(priceDtoList, volumeDtoList, hasMore);
+    });
+  }
+
+  mapResultListToPriceDtoList(resultList: StockData[]): PriceDto[] {
+    return resultList
+      .map((data: StockData) => ({
+        startTime: data.startTime,
+        open: data.open,
+        close: data.close,
+        high: data.high,
+        low: data.low,
+      }))
+      .reverse();
+  }
+
+  mapResultListToVolumeDtoList(resultList: StockData[]): VolumeDto[] {
+    return resultList
+      .map((data) => ({
+        startTime: data.startTime,
+        volume: data.volume,
+      }))
+      .reverse();
+  }
+
+  createStockDataResponse(
+    priceDtoList: PriceDto[],
+    volumeDtoList: VolumeDto[],
+    hasMore: boolean,
+  ): StockDataResponse {
+    const priceData = plainToInstance(PriceDto, priceDtoList);
+    const volumeData = plainToInstance(VolumeDto, volumeDtoList);
+
+    const responseDto = plainToInstance(StockDataResponse, {
+      priceDtoList: priceData,
+      volumeDtoList: volumeData,
+      hasMore,
+    });
+
+    return responseDto;
+  }
+}
+
+@Injectable()
+export class StockDataMinutelyService extends StockDataService {
+  constructor(dataSource: DataSource) {
+    super(dataSource);
+  }
+  async getStockDataMinutely(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    const response = await this.getPaginated(
+      StockMinutely,
+      stock_id,
+      lastStartTime,
+    );
+
+    return response;
+  }
+}
+
+@Injectable()
+export class StockDataDailyService extends StockDataService {
+  constructor(dataSource: DataSource) {
+    super(dataSource);
+  }
+  async getStockDataDaily(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    const response = await this.getPaginated(
+      StockDaily,
+      stock_id,
+      lastStartTime,
+    );
+
+    return response;
+  }
+}
+
+@Injectable()
+export class StockDataWeeklyService extends StockDataService {
+  constructor(dataSource: DataSource) {
+    super(dataSource);
+  }
+  async getStockDataWeekly(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    const response = await this.getPaginated(
+      StockWeekly,
+      stock_id,
+      lastStartTime,
+    );
+
+    return response;
+  }
+}
+
+@Injectable()
+export class StockDataMonthlyService extends StockDataService {
+  constructor(dataSource: DataSource) {
+    super(dataSource);
+  }
+  async getStockDataMonthly(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    const response = await this.getPaginated(
+      StockMonthly,
+      stock_id,
+      lastStartTime,
+    );
+
+    return response;
+  }
+}
+
+@Injectable()
+export class StockDataYearlyService extends StockDataService {
+  constructor(dataSource: DataSource) {
+    super(dataSource);
+  }
+  async getStockDataYearly(
+    stock_id: string,
+    lastStartTime?: string,
+  ): Promise<StockDataResponse> {
+    const response = await this.getPaginated(
+      StockYearly,
+      stock_id,
+      lastStartTime,
+    );
+
+    return response;
+  }
+}


### PR DESCRIPTION
close #22 

## ✅ 작업 내용

- 주식 데이터 엔티티 정의
- 응답 DTO 추가
- StockDataService 구현
- StockDataService 상속으로 시간 단위 별 서비스 구현
- getStockData 데코레이터 추가
- 웹소켓 게이트웨이 경로 수정
- 존재하지 않는 주식 조회 시 NotFoundException 추가

## ✍ 궁금한 점

- 공통 부분 로직을 클래스로 뽑아서 이를 상속해서 만들었는데 지금 방식은 너무 서비스들이 많아지는데 차라리 내부에 메소드로 하는게 나을지?
  - 각 엔티티가 분리되어 있기 때문에 서비스들이 필요하다고 생각해서 지금 형식으로 구현
  - 사실상 같은 형식의 데이터들을 시간단위로 나누어 놓은 것이기 때문에 한 서비스에서 해도 괜찮을지?
- 차트 데이터 부분은 아니지만 실시간 데이터에서 데이터 저장을 ORM을 통해서 하는지?

## 😎 체크 사항

- [X] label 설정 확인
- [X] 브랜치 방향 확인
