### PR TITLE
Feature/#123 - 주식 조회수 증가 api 연결

### DIFF
--- a/packages/frontend/src/apis/queries/stock-detail/index.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/index.ts
@@ -1,0 +1,1 @@
+export * from './usePostStockView';

--- a/packages/frontend/src/apis/queries/stock-detail/types.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/types.ts
@@ -1,0 +1,9 @@
+export interface PostStockViewRequest {
+  stockId: string;
+}
+
+export interface PostStockViewResponse {
+  id: string;
+  message: string;
+  date: Date;
+}

--- a/packages/frontend/src/apis/queries/stock-detail/usePostStockView.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/usePostStockView.ts
@@ -1,0 +1,20 @@
+import type { PostStockViewRequest, PostStockViewResponse } from './types';
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import { instance } from '@/apis/config';
+
+const postStockView = async ({
+  stockId,
+}: PostStockViewRequest): Promise<PostStockViewResponse> => {
+  const { data } = await instance.post('/api/stock/view', { stockId });
+  return data;
+};
+
+export const usePostStockView = (
+  options?: UseMutationOptions<PostStockViewResponse, Error, string>,
+) => {
+  return useMutation<PostStockViewResponse, Error, string>({
+    mutationKey: ['stock_view'],
+    mutationFn: (stockId) => postStockView({ stockId }),
+    ...options,
+  });
+};

--- a/packages/frontend/src/pages/stocks/StockRankingTable.tsx
+++ b/packages/frontend/src/pages/stocks/StockRankingTable.tsx
@@ -1,14 +1,17 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { usePostStockView } from '@/apis/queries/stock-detail';
 import { useGetStocksByPrice } from '@/apis/queries/stocks';
 import DownArrow from '@/assets/down-arrow.svg?react';
 import { cn } from '@/utils/cn';
 
+const LIMIT = 20;
+
 export const StockRankingTable = () => {
-  const LIMIT = 20;
   const [isGaining, setIsGaining] = useState(true);
 
   const { data } = useGetStocksByPrice({ limit: LIMIT, isGaining });
+  const { mutate } = usePostStockView();
 
   return (
     <div className="rounded-md bg-white px-6 shadow">
@@ -48,6 +51,7 @@ export const StockRankingTable = () => {
                 <span className="text-gray w-3 flex-shrink-0">{index + 1}</span>
                 <Link
                   to={`${stock.id}`}
+                  onClick={() => mutate(stock.id)}
                   className="display-bold14 hover:text-orange cursor-pointer text-ellipsis hover:underline"
                   aria-label={stock.name}
                 >


### PR DESCRIPTION
close #123 

## ✅ 작업 내용

- 개별 주식 선택시 조회수 증가 api 연결
- 주식 리스트 테이블에서 선택시 api 요청하도록 구현
  - 주식 개별 페이지에서 증가시킨다면 새로고침 시에도 조회수 증가 요청이 가기 때문에 메인페이지에서 진행

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
