### PR TITLE
Feature/#107 - 채팅기능 구현, 주식 소유 수정

### DIFF
--- a/packages/frontend/src/apis/config/index.ts
+++ b/packages/frontend/src/apis/config/index.ts
@@ -1,7 +1,24 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,
-  timeout: 1000,
+  timeout: 10000,
   withCredentials: true,
 });
+
+instance.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const status = error.response?.status;
+
+    if (status === 400) {
+      alert('잘못된 요청입니다.');
+    }
+
+    if (status === 403) {
+      alert('로그인이 필요합니다.');
+      location.href = '/login';
+    }
+    return Promise.reject(error);
+  },
+);

--- a/packages/frontend/src/apis/config/index.ts
+++ b/packages/frontend/src/apis/config/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,
-  timeout: 10000,
+  timeout: 1000,
   withCredentials: true,
 });
 

--- a/packages/frontend/src/apis/queries/auth/schema.ts
+++ b/packages/frontend/src/apis/queries/auth/schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const GetLoginStatusSchema = z.object({
   message: z.enum(['Authenticated', 'Not Authenticated']),
-  nickname: z.string(),
+  nickname: z.string().nullish(),
 });
 
 export type GetLoginStatus = z.infer<typeof GetLoginStatusSchema>;

--- a/packages/frontend/src/apis/queries/auth/schema.ts
+++ b/packages/frontend/src/apis/queries/auth/schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const GetLoginStatusSchema = z.object({
   message: z.enum(['Authenticated', 'Not Authenticated']),
+  nickname: z.string(),
 });
 
 export type GetLoginStatus = z.infer<typeof GetLoginStatusSchema>;

--- a/packages/frontend/src/apis/queries/chat/index.ts
+++ b/packages/frontend/src/apis/queries/chat/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './usePostChatLike';

--- a/packages/frontend/src/apis/queries/chat/schema.ts
+++ b/packages/frontend/src/apis/queries/chat/schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const GetChatLikeRequestSchema = z.object({
+  chatId: z.number(),
+});
+
+export type GetChatLikeRequest = z.infer<typeof GetChatLikeRequestSchema>;
+
+export const GetChatLikeResponseSchema = z.object({
+  chatId: z.number(),
+  stockId: z.string(),
+  likeCount: z.number(),
+  message: z.string(),
+  date: z.string().datetime(),
+});
+
+export type GetChatLikeResponse = z.infer<typeof GetChatLikeResponseSchema>;

--- a/packages/frontend/src/apis/queries/chat/usePostChatLike.ts
+++ b/packages/frontend/src/apis/queries/chat/usePostChatLike.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  GetChatLikeResponseSchema,
+  type GetChatLikeRequest,
+  type GetChatLikeResponse,
+} from './schema';
+import { post } from '@/apis/utils/post';
+
+const postChatLike = ({ chatId }: GetChatLikeRequest) =>
+  post<GetChatLikeResponse>({
+    params: { chatId },
+    schema: GetChatLikeResponseSchema,
+    url: '/api/chat/like',
+  });
+
+export const usePostChatLike = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['chatLike'],
+    mutationFn: ({ chatId }: GetChatLikeRequest) => postChatLike({ chatId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['chatLike'] });
+    },
+  });
+};

--- a/packages/frontend/src/apis/queries/stock-detail/schema.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/schema.ts
@@ -41,7 +41,7 @@ export type GetStockOwnershipResponse = z.infer<
 >;
 
 export const DeleteStockUserRequestSchema = z.object({
-  userStockId: z.string(),
+  stockId: z.string(),
 });
 
 export type DeleteStockUserRequest = z.infer<
@@ -49,7 +49,7 @@ export type DeleteStockUserRequest = z.infer<
 >;
 
 export const DeleteStockUserSchema = z.object({
-  userStockId: z.string(),
+  stockId: z.string(),
   message: z.string(),
   date: z.string().datetime(),
 });

--- a/packages/frontend/src/apis/queries/stock-detail/schema.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/schema.ts
@@ -49,7 +49,7 @@ export type DeleteStockUserRequest = z.infer<
 >;
 
 export const DeleteStockUserSchema = z.object({
-  stockId: z.string(),
+  id: z.string(),
   message: z.string(),
   date: z.string().datetime(),
 });

--- a/packages/frontend/src/apis/queries/stock-detail/useDeleteStockUser.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/useDeleteStockUser.ts
@@ -6,17 +6,17 @@ import {
 } from './schema';
 import { deleteRequest } from '@/apis/utils/delete';
 
-const deleteStockUser = ({ userStockId }: DeleteStockUserRequest) =>
+const deleteStockUser = ({ stockId }: DeleteStockUserRequest) =>
   deleteRequest<DeleteStockUser>({
     schema: DeleteStockUserSchema,
-    url: 'api/stock/user',
-    params: { userStockId },
+    url: '/api/stock/user',
+    params: { stockId },
   });
 
 export const useDeleteStockUser = () => {
   return useMutation({
     mutationKey: ['deleteStockUser'],
-    mutationFn: ({ userStockId }: DeleteStockUserRequest) =>
-      deleteStockUser({ userStockId }),
+    mutationFn: ({ stockId }: DeleteStockUserRequest) =>
+      deleteStockUser({ stockId }),
   });
 };

--- a/packages/frontend/src/apis/queries/stock-detail/useDeleteStockUser.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/useDeleteStockUser.ts
@@ -10,13 +10,14 @@ const deleteStockUser = ({ stockId }: DeleteStockUserRequest) =>
   deleteRequest<DeleteStockUser>({
     schema: DeleteStockUserSchema,
     url: '/api/stock/user',
-    params: { stockId },
+    data: { stockId },
   });
 
-export const useDeleteStockUser = () => {
+export const useDeleteStockUser = ({ ...options }) => {
   return useMutation({
     mutationKey: ['deleteStockUser'],
     mutationFn: ({ stockId }: DeleteStockUserRequest) =>
       deleteStockUser({ stockId }),
+    ...options,
   });
 };

--- a/packages/frontend/src/apis/queries/stock-detail/useGetStockOwnership.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/useGetStockOwnership.ts
@@ -15,7 +15,7 @@ const getOwnership = ({ stockId }: GetStockRequest) =>
 
 export const useGetOwnership = ({ stockId }: GetStockRequest) => {
   return useQuery({
-    queryKey: ['stockOwnership'],
+    queryKey: ['stockOwnership', stockId],
     queryFn: () => getOwnership({ stockId }),
     enabled: !!stockId,
   });

--- a/packages/frontend/src/apis/queries/stock-detail/usePostStockUser.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/usePostStockUser.ts
@@ -13,9 +13,10 @@ const postStockUser = ({ stockId }: PostStockRequest) =>
     url: '/api/stock/user',
   });
 
-export const usePostStockUser = () => {
+export const usePostStockUser = ({ ...options }) => {
   return useMutation({
     mutationKey: ['addStock'],
     mutationFn: ({ stockId }: PostStockRequest) => postStockUser({ stockId }),
+    ...options,
   });
 };

--- a/packages/frontend/src/apis/queries/stock-detail/usePostStockUser.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/usePostStockUser.ts
@@ -8,9 +8,9 @@ import { post } from '@/apis/utils/post';
 
 const postStockUser = ({ stockId }: PostStockRequest) =>
   post<PostStockResponse>({
-    params: stockId,
+    params: { stockId },
     schema: PostStockResponseSchema,
-    url: 'api/stock/user',
+    url: '/api/stock/user',
   });
 
 export const usePostStockUser = () => {

--- a/packages/frontend/src/apis/queries/stock-detail/usePostStockView.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/usePostStockView.ts
@@ -8,9 +8,9 @@ import { post } from '@/apis/utils/post';
 
 const postStockView = ({ stockId }: PostStockRequest) =>
   post<PostStockResponse>({
-    params: stockId,
+    params: { stockId },
     schema: PostStockResponseSchema,
-    url: 'api/stock/view',
+    url: '/api/stock/view',
   });
 
 export const usePostStockView = () => {

--- a/packages/frontend/src/apis/queries/stocks/schema.ts
+++ b/packages/frontend/src/apis/queries/stocks/schema.ts
@@ -21,6 +21,8 @@ export const GetStockListResponseSchema = z.object({
   result: z.array(GetStockSchema),
 });
 
+export type GetStockTopViewsResponse = z.infer<typeof GetStockSchema>;
+
 export type GetStockListResponse = z.infer<typeof GetStockListResponseSchema>;
 
 export const StockTimeSeriesRequestSchema = z.object({

--- a/packages/frontend/src/apis/queries/stocks/schema.ts
+++ b/packages/frontend/src/apis/queries/stocks/schema.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 export const GetStockListRequestSchema = z.object({
   limit: z.number(),
-  sortType: z.enum(['increase', 'decrease']),
 });
 
 export type GetStockListRequest = z.infer<typeof GetStockListRequestSchema>;

--- a/packages/frontend/src/apis/queries/stocks/schema.ts
+++ b/packages/frontend/src/apis/queries/stocks/schema.ts
@@ -7,13 +7,18 @@ export const GetStockListRequestSchema = z.object({
 
 export type GetStockListRequest = z.infer<typeof GetStockListRequestSchema>;
 
-export const GetStockListResponseSchema = z.object({
+export const GetStockSchema = z.object({
   id: z.string(),
   name: z.string(),
   currentPrice: z.number(),
   changeRate: z.number(),
   volume: z.number(),
   marketCap: z.string(),
+  rank: z.number(),
+});
+
+export const GetStockListResponseSchema = z.object({
+  result: z.array(GetStockSchema),
 });
 
 export type GetStockListResponse = z.infer<typeof GetStockListResponseSchema>;

--- a/packages/frontend/src/apis/queries/stocks/useGetStocksByPrice.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetStocksByPrice.ts
@@ -6,29 +6,16 @@ import {
 } from './schema';
 import { get } from '@/apis/utils/get';
 
-const getTopGainers = ({ limit }: Partial<GetStockListRequest>) =>
+const getStockByPrice = ({ limit }: Partial<GetStockListRequest>) =>
   get<GetStockListResponse>({
     schema: GetStockListResponseSchema,
-    url: `/api/stock/topGainers`,
+    url: `/api/stock/fluctuation`,
     params: { limit },
   });
 
-const getTopLosers = ({ limit }: Partial<GetStockListRequest>) =>
-  get<GetStockListResponse>({
-    schema: GetStockListResponseSchema,
-    url: `/api/stock/topLosers`,
-    params: { limit },
-  });
-
-export const useGetStocksByPrice = ({
-  limit,
-  sortType,
-}: GetStockListRequest) => {
+export const useGetStocksByPrice = ({ limit }: GetStockListRequest) => {
   return useQuery({
-    queryKey: ['stocks', sortType, limit],
-    queryFn:
-      sortType === 'increase'
-        ? () => getTopGainers({ limit })
-        : () => getTopLosers({ limit }),
+    queryKey: ['stocks', limit],
+    queryFn: () => getStockByPrice({ limit }),
   });
 };

--- a/packages/frontend/src/apis/queries/stocks/useGetStocksByPrice.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetStocksByPrice.ts
@@ -7,14 +7,14 @@ import {
 import { get } from '@/apis/utils/get';
 
 const getTopGainers = ({ limit }: Partial<GetStockListRequest>) =>
-  get<GetStockListResponse[]>({
+  get<GetStockListResponse>({
     schema: GetStockListResponseSchema,
     url: `/api/stock/topGainers`,
     params: { limit },
   });
 
 const getTopLosers = ({ limit }: Partial<GetStockListRequest>) =>
-  get<GetStockListResponse[]>({
+  get<GetStockListResponse>({
     schema: GetStockListResponseSchema,
     url: `/api/stock/topLosers`,
     params: { limit },
@@ -25,7 +25,7 @@ export const useGetStocksByPrice = ({
   sortType,
 }: GetStockListRequest) => {
   return useQuery({
-    queryKey: ['stocks', sortType],
+    queryKey: ['stocks', sortType, limit],
     queryFn:
       sortType === 'increase'
         ? () => getTopGainers({ limit })

--- a/packages/frontend/src/apis/queries/stocks/useGetTopViews.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetTopViews.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import {
   GetStockListResponseSchema,
+  GetStockTopViewsResponse,
   type GetStockListRequest,
-  type GetStockListResponse,
 } from './schema';
 import { get } from '@/apis/utils/get';
 
 const getTopViews = ({ limit }: Partial<GetStockListRequest>) =>
-  get<GetStockListResponse>({
+  get<GetStockTopViewsResponse[]>({
     schema: GetStockListResponseSchema,
     url: `/api/stock/topViews`,
     params: { limit },

--- a/packages/frontend/src/apis/queries/stocks/useGetTopViews.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetTopViews.ts
@@ -7,7 +7,7 @@ import {
 import { get } from '@/apis/utils/get';
 
 const getTopViews = ({ limit }: Partial<GetStockListRequest>) =>
-  get<GetStockListResponse[]>({
+  get<GetStockListResponse>({
     schema: GetStockListResponseSchema,
     url: `/api/stock/topViews`,
     params: { limit },

--- a/packages/frontend/src/apis/utils/delete.ts
+++ b/packages/frontend/src/apis/utils/delete.ts
@@ -1,21 +1,21 @@
-import { AxiosRequestConfig } from 'axios';
+/* eslint-disable */
 import { z } from 'zod';
 import { instance } from '../config';
 import { formatZodError } from './formatZodError';
 
 interface DeleteParams {
-  params: AxiosRequestConfig['params'];
+  data: any;
   schema: z.ZodType;
   url: string;
 }
 
 export const deleteRequest = async <T>({
-  params,
+  data,
   schema,
   url,
 }: DeleteParams): Promise<T> => {
-  const { data } = await instance.delete(url, { params });
-  const result = schema.safeParse(data);
+  const response = await instance.delete(url, { data });
+  const result = schema.safeParse(response.data);
 
   if (!result.success) {
     throw new Error(formatZodError(result.error));

--- a/packages/frontend/src/apis/utils/post.ts
+++ b/packages/frontend/src/apis/utils/post.ts
@@ -14,7 +14,7 @@ export const post = async <T>({
   schema,
   url,
 }: PostParams): Promise<T> => {
-  const { data } = await instance.post(url, { params });
+  const { data } = await instance.post(url, params);
   const result = schema.safeParse(data);
 
   if (!result.success) {

--- a/packages/frontend/src/components/layouts/Layout.tsx
+++ b/packages/frontend/src/components/layouts/Layout.tsx
@@ -6,7 +6,7 @@ export const Layout = () => {
     <div className="flex min-h-screen">
       <Sidebar />
       <main className="ml-20 flex-1">
-        <div className="h-full overflow-auto px-48 py-16">
+        <div className="h-full overflow-auto px-16 py-16 md:px-32 lg:px-48">
           <Outlet />
         </div>
       </main>

--- a/packages/frontend/src/components/ui/modal/Modal.tsx
+++ b/packages/frontend/src/components/ui/modal/Modal.tsx
@@ -6,16 +6,9 @@ interface ModalProps {
   children: string;
   onClose: () => void;
   onConfirm: () => void;
-  isShowButton: boolean;
 }
 
-export const Modal = ({
-  title,
-  children,
-  onClose,
-  onConfirm,
-  isShowButton,
-}: ModalProps) => {
+export const Modal = ({ title, children, onClose, onConfirm }: ModalProps) => {
   const ref = useOutsideClick(onClose);
 
   return (
@@ -28,18 +21,16 @@ export const Modal = ({
           <h2 className="display-bold20">{title}</h2>
           <p>{children}</p>
         </section>
-        {isShowButton && (
-          <section className="flex gap-3">
-            <Button onClick={onClose}>취소</Button>
-            <Button
-              backgroundColor="orange"
-              textColor="white"
-              onClick={onConfirm}
-            >
-              확인
-            </Button>
-          </section>
-        )}
+        <section className="flex gap-3">
+          <Button onClick={onClose}>취소</Button>
+          <Button
+            backgroundColor="orange"
+            textColor="white"
+            onClick={onConfirm}
+          >
+            확인
+          </Button>
+        </section>
       </div>
     </div>
   );

--- a/packages/frontend/src/constants/chatPlaceholder.ts
+++ b/packages/frontend/src/constants/chatPlaceholder.ts
@@ -1,0 +1,16 @@
+export type ChatPlaceholder =
+  | 'NOT_AUTHENTICATED'
+  | 'NOT_OWNERSHIP'
+  | 'OWNERSHIP';
+
+export const chatPlaceholder = {
+  NOT_AUTHENTICATED: {
+    message: '로그인 후 입력 가능합니다.',
+  },
+  NOT_OWNERSHIP: {
+    message: '주주 소유자만 입력 가능합니다.',
+  },
+  OWNERSHIP: {
+    message: '100자 이내로 입력 가능합니다.',
+  },
+};

--- a/packages/frontend/src/constants/metricDetail.ts
+++ b/packages/frontend/src/constants/metricDetail.ts
@@ -47,6 +47,7 @@ export const METRICS_DATA = ({
 }: StockMetricsPanelProps) => {
   return {
     price: {
+      id: 1,
       title: '가격',
       metrics: [
         {
@@ -68,6 +69,7 @@ export const METRICS_DATA = ({
       ],
     },
     enterpriseValue: {
+      id: 2,
       title: '기업가치',
       metrics: [
         {

--- a/packages/frontend/src/constants/modalMessage.ts
+++ b/packages/frontend/src/constants/modalMessage.ts
@@ -3,17 +3,14 @@ export type ModalMessage = 'NOT_AUTHENTICATED' | 'NOT_OWNERSHIP' | 'OWNERSHIP';
 export const modalMessage = {
   NOT_AUTHENTICATED: {
     label: '내 주식 추가',
-    message: '로그인 후 이용가능합니다.',
-    button: false,
+    message: '로그인 후 이용가능합니다. \n로그인하시겠습니까?',
   },
   NOT_OWNERSHIP: {
     label: '내 주식 추가',
     message: '이 주식을 소유하시겠습니까?',
-    button: true,
   },
   OWNERSHIP: {
     label: '내 주식 삭제',
     message: '이 주식 소유를 취소하시겠습니까?',
-    button: true,
   },
 };

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -94,6 +94,14 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
     };
   }, [stockId, socket, handleChat]);
 
+  const handleLikeClick = (chatId: number) => {
+    if (isOwnerStock) {
+      mutate({ chatId });
+      return;
+    }
+    alert('주주 소유자만 가능합니다.');
+  };
+
   return (
     <article className="flex min-w-80 flex-col gap-5 rounded-md bg-white p-7">
       <h2 className="display-bold20 text-center font-bold">채팅</h2>
@@ -111,7 +119,12 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
       </div>
       <article className="relative">
         {!isOwnerStock && (
-          <div className="display-bold16 absolute top-64 flex h-[calc(100%-16rem)] w-full items-center justify-center bg-black/5 text-center backdrop-blur-sm">
+          <div
+            className={cn(
+              'display-bold16 absolute top-64 flex h-[calc(100%-16rem)] w-full items-center justify-center bg-black/5 text-center backdrop-blur-sm',
+              chatData.length < 3 && 'top-0 h-full',
+            )}
+          >
             <span>
               주주 소유자만
               <br /> 확인할 수 있습니다.
@@ -134,7 +147,7 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
                 likeCount={chat.likeCount}
                 liked={chat.liked}
                 writer={nickname || ''}
-                onClick={() => mutate({ chatId: chat.id })}
+                onClick={() => handleLikeClick(chat.id)}
               />
             ))
           ) : (

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -1,45 +1,64 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { TextArea } from './components';
 import { ChatMessage } from './components/ChatMessage';
+import { GetLoginStatus } from '@/apis/queries/auth/schema';
+import { usePostChatLike } from '@/apis/queries/chat';
 import DownArrow from '@/assets/down-arrow.svg?react';
+import { ChatPlaceholder, chatPlaceholder } from '@/constants/chatPlaceholder';
 import { socketChat } from '@/sockets/config';
 import {
-  ChatDataSchema,
+  ChatDataResponseSchema,
   type ChatData,
   type ChatDataResponse,
 } from '@/sockets/schema';
 import { useWebsocket } from '@/sockets/useWebsocket';
 
-export const ChatPanel = () => {
-  const STOCK_ID = '005930';
-  const [chatData, setChatData] = useState<ChatData[]>();
+interface ChatPanelProps {
+  loginStatus: GetLoginStatus['message'];
+  isOwnerStock: boolean;
+}
+
+export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
+  const { stockId = '' } = useParams();
+  const [chatData, setChatData] = useState<ChatData[]>([]);
+  const { mutate } = usePostChatLike();
 
   const socket = useMemo(() => {
-    return socketChat({ stockId: STOCK_ID });
-  }, [STOCK_ID]);
+    return socketChat({ stockId });
+  }, [stockId]);
 
   const { isConnected } = useWebsocket(socket);
+
+  const userStatus: ChatPlaceholder = useMemo(() => {
+    if (loginStatus === 'Not Authenticated') {
+      return 'NOT_AUTHENTICATED';
+    }
+
+    return isOwnerStock ? 'OWNERSHIP' : 'NOT_OWNERSHIP';
+  }, [loginStatus, isOwnerStock]);
+
+  const handleChat = (message: ChatDataResponse) => {
+    const validatedChatData = ChatDataResponseSchema.safeParse(message);
+
+    if (validatedChatData.success && message?.chats) {
+      setChatData((prev) => [...prev, ...message.chats]);
+    }
+  };
 
   const handleSendMessage = (message: string) => {
     if (isConnected) {
       socket.emit('chat', {
-        room: STOCK_ID,
+        room: stockId,
         content: message,
       });
     }
   };
 
   useEffect(() => {
-    const handleChat = (message: ChatDataResponse) => {
-      const validatedChatData = ChatDataSchema.safeParse(message?.chats);
-
-      if (validatedChatData.success && message?.chats) {
-        setChatData(message.chats);
-      }
-    };
-
     if (isConnected) {
       socket.on('chat', handleChat);
+      // socket.on('like');
 
       return () => {
         socket.off('chat', handleChat);
@@ -50,20 +69,25 @@ export const ChatPanel = () => {
   return (
     <article className="flex flex-col gap-5 rounded-md bg-white p-7">
       <h2 className="display-bold20 text-center font-bold">채팅</h2>
-      <TextArea onSend={handleSendMessage} />
+      <TextArea
+        onSend={handleSendMessage}
+        disabled={!isOwnerStock}
+        placeholder={chatPlaceholder[userStatus].message}
+      />
       <div className="border-light-gray flex items-center justify-end gap-1 border-b-2 pb-2">
         <p className="display-medium12 text-dark-gray">최신순</p>
         <DownArrow className="cursor-pointer" />
       </div>
-      <section className="flex flex-col gap-5">
+      <section className="flex h-[40rem] flex-col gap-5 overflow-auto">
         {chatData ? (
-          chatData.map((chat) => (
+          chatData.map((chat, index) => (
             <ChatMessage
-              key={chat.id}
+              key={index}
               name={chat.nickname}
               contents={chat.message}
               likeCount={chat.likeCount}
               liked={chat.liked}
+              onClick={() => mutate({ chatId: chat.id })}
             />
           ))
         ) : (

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -122,7 +122,7 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
           <div
             className={cn(
               'display-bold16 absolute top-64 flex h-[calc(100%-16rem)] w-full items-center justify-center bg-black/5 text-center backdrop-blur-sm',
-              chatData.length < 3 && 'top-0 h-full',
+              chatData.length < 4 && 'top-0 h-full',
             )}
           >
             <span>

--- a/packages/frontend/src/pages/stock-detail/StockDetail.tsx
+++ b/packages/frontend/src/pages/stock-detail/StockDetail.tsx
@@ -34,7 +34,7 @@ export const StockDetail = () => {
         loginStatus={loginStatus}
         isOwnerStock={userOwnerStock.isOwner}
       />
-      <article className="grid flex-1 grid-cols-[2.5fr_1fr_1fr] gap-5 [&_section]:gap-5">
+      <article className="grid flex-1 grid-cols-1 gap-5 lg:grid-cols-2 xl:grid-cols-[2.5fr_1fr_1fr] [&_section]:gap-5">
         <section className="flex flex-col">
           <div className="relative h-full">
             <TradingChart />
@@ -51,9 +51,9 @@ export const StockDetail = () => {
           loginStatus={loginStatus}
           isOwnerStock={userOwnerStock.isOwner}
         />
-        <section className="flex flex-col">
-          <NotificationPanel className="h-1/2" />
-          <AddAlarmForm className="h-1/2" />
+        <section className="flex flex-row flex-wrap gap-5 lg:flex-col xl:flex-nowrap">
+          <NotificationPanel className="h-full w-full xl:h-1/2" />
+          <AddAlarmForm className="h-full w-full xl:h-1/2" />
         </section>
       </article>
     </div>

--- a/packages/frontend/src/pages/stock-detail/StockDetail.tsx
+++ b/packages/frontend/src/pages/stock-detail/StockDetail.tsx
@@ -7,20 +7,34 @@ import {
   StockMetricsPanel,
   TradingChart,
 } from '.';
-import { useGetStockDetail } from '@/apis/queries/stock-detail';
+import { useGetLoginStatus } from '@/apis/queries/auth';
+import {
+  useGetOwnership,
+  useGetStockDetail,
+} from '@/apis/queries/stock-detail';
 
 export const StockDetail = () => {
-  const { stockId } = useParams();
-  const { data: stockDetail } = useGetStockDetail({ stockId: stockId ?? '' });
-  const { eps, high52w, low52w, marketCap, per } = stockDetail || {};
+  const { stockId = '' } = useParams();
+
+  const { data: stockDetail } = useGetStockDetail({ stockId });
+  const { eps, high52w, low52w, marketCap, per, name } = stockDetail || {};
+
+  const { data: loginStatus } = useGetLoginStatus();
+  const { data: userOwnerStock } = useGetOwnership({ stockId });
+
+  if (!stockDetail || !loginStatus || !userOwnerStock) {
+    return <div>데이터가 없습니다.</div>;
+  }
 
   return (
     <div className="flex h-full flex-col gap-7">
       <StockDetailHeader
-        stockId={stockId ?? ''}
-        stockName={stockDetail?.name ?? ''}
+        stockId={stockId}
+        stockName={name || ''}
+        loginStatus={loginStatus.message}
+        isOwnerStock={userOwnerStock.isOwner}
       />
-      <article className="grid flex-1 grid-cols-[2.5fr_1fr_1fr] gap-5 [&_section]:gap-5">
+      <article className="grid flex-1 grid-cols-2 gap-5 [&_section]:gap-5">
         <section className="flex flex-col">
           <div className="relative h-full">
             <TradingChart />
@@ -33,7 +47,10 @@ export const StockDetail = () => {
             per={per}
           />
         </section>
-        <ChatPanel />
+        <ChatPanel
+          loginStatus={loginStatus.message}
+          isOwnerStock={userOwnerStock.isOwner}
+        />
         <section className="flex flex-col">
           <NotificationPanel className="h-1/2" />
           <AddAlarmForm className="h-1/2" />

--- a/packages/frontend/src/pages/stock-detail/StockDetail.tsx
+++ b/packages/frontend/src/pages/stock-detail/StockDetail.tsx
@@ -31,10 +31,10 @@ export const StockDetail = () => {
       <StockDetailHeader
         stockId={stockId}
         stockName={name || ''}
-        loginStatus={loginStatus.message}
+        loginStatus={loginStatus}
         isOwnerStock={userOwnerStock.isOwner}
       />
-      <article className="grid flex-1 grid-cols-2 gap-5 [&_section]:gap-5">
+      <article className="grid flex-1 grid-cols-[2.5fr_1fr_1fr] gap-5 [&_section]:gap-5">
         <section className="flex flex-col">
           <div className="relative h-full">
             <TradingChart />
@@ -48,7 +48,7 @@ export const StockDetail = () => {
           />
         </section>
         <ChatPanel
-          loginStatus={loginStatus.message}
+          loginStatus={loginStatus}
           isOwnerStock={userOwnerStock.isOwner}
         />
         <section className="flex flex-col">

--- a/packages/frontend/src/pages/stock-detail/StockMetricsPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/StockMetricsPanel.tsx
@@ -26,9 +26,9 @@ export const StockMetricsPanel = ({
   return (
     <article className="flex flex-col gap-10 rounded-md bg-white p-6 shadow">
       {Object.values(metricsData).map((section) => (
-        <section className="flex flex-col">
+        <section className="flex flex-col" key={section.id}>
           <Title>{section.title}</Title>
-          <section className="grid grid-cols-[repeat(4,100px)] items-center">
+          <section className="grid w-9/12 grid-cols-4 items-center">
             {section.metrics.map((metric) => (
               <MetricItem
                 key={metric.name}

--- a/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
@@ -6,6 +6,7 @@ interface ChatMessageProps {
   contents: string;
   likeCount: number;
   liked: boolean;
+  onClick: () => void;
 }
 
 export const ChatMessage = ({
@@ -13,20 +14,20 @@ export const ChatMessage = ({
   contents,
   likeCount,
   liked,
+  onClick,
 }: ChatMessageProps) => {
   return (
     <div className="flex">
-      <p className="display-bold12 text-dark-gray mr-3 w-12 flex-shrink-0">
-        {name}
-      </p>
+      <p className="display-bold14 text-dark-gray mr-3 w-fit">{name}</p>
       <div>
-        <p className="display-medium12 text-dark-gray">{contents}</p>
+        <p className="display-medium14 text-dark-gray">{contents}</p>
         <div className="flex items-center gap-1">
           <Like
-            className={
-              (cn('hover:fill-orange cursor-pointer'),
-              liked ? 'fill-orange' : 'fill-gray')
-            }
+            className={cn(
+              'hover:fill-orange cursor-pointer',
+              liked ? 'fill-orange' : 'fill-gray',
+            )}
+            onClick={onClick}
           />
           <span className="display-medium12 text-gray">{likeCount}</span>
         </div>

--- a/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
@@ -39,12 +39,19 @@ export const ChatMessage = ({
         >
           <Like
             className={cn(
-              'hover:fill-orange cursor-pointer',
+              'hover:fill-orange active:fill-orange cursor-pointer',
               liked ? 'fill-orange' : 'fill-gray',
             )}
             onClick={onClick}
           />
-          <span className="display-medium12 text-gray">{likeCount}</span>
+          <span
+            className={cn(
+              'display-medium12',
+              liked ? 'text-orange' : 'text-gray',
+            )}
+          >
+            {likeCount}
+          </span>
         </div>
       </div>
     </div>

--- a/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
@@ -1,3 +1,4 @@
+import { MouseEventHandler } from 'react';
 import Like from '@/assets/like.svg?react';
 import { cn } from '@/utils/cn';
 
@@ -6,7 +7,8 @@ interface ChatMessageProps {
   contents: string;
   likeCount: number;
   liked: boolean;
-  onClick: () => void;
+  onClick: MouseEventHandler<SVGElement>;
+  writer: string;
 }
 
 export const ChatMessage = ({
@@ -15,13 +17,26 @@ export const ChatMessage = ({
   likeCount,
   liked,
   onClick,
+  writer,
 }: ChatMessageProps) => {
   return (
-    <div className="flex">
-      <p className="display-bold14 text-dark-gray mr-3 w-fit">{name}</p>
-      <div>
+    <div className={cn('flex flex-col', writer === name ? 'items-end' : '')}>
+      <p
+        className={cn(
+          'display-bold14 text-dark-gray w-fit',
+          writer === name && 'text-orange',
+        )}
+      >
+        {name}
+      </p>
+      <div className="flex flex-col gap-2">
         <p className="display-medium14 text-dark-gray">{contents}</p>
-        <div className="flex items-center gap-1">
+        <div
+          className={cn(
+            'flex items-center gap-1',
+            writer === name ? 'justify-end' : '',
+          )}
+        >
           <Like
             className={cn(
               'hover:fill-orange cursor-pointer',

--- a/packages/frontend/src/pages/stock-detail/components/StockDetailHeader.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/StockDetailHeader.tsx
@@ -45,18 +45,16 @@ export const StockDetailHeader = ({
   const { mutate: postStockUser } = usePostStockUser({
     onSuccess: () => {
       setUserStatus('OWNERSHIP');
-      queryClient.invalidateQueries({
-        queryKey: ['loginStatus', 'stockOwnership', stockId],
-      });
+      queryClient.invalidateQueries({ queryKey: ['loginStatus'] });
+      queryClient.invalidateQueries({ queryKey: ['stockOwnership', stockId] });
     },
   });
 
   const { mutate: deleteStockUser } = useDeleteStockUser({
     onSuccess: () => {
       setUserStatus('NOT_OWNERSHIP');
-      queryClient.invalidateQueries({
-        queryKey: ['loginStatus', 'stockOwnership', stockId],
-      });
+      queryClient.invalidateQueries({ queryKey: ['loginStatus'] });
+      queryClient.invalidateQueries({ queryKey: ['stockOwnership', stockId] });
     },
   });
 

--- a/packages/frontend/src/pages/stock-detail/components/StockDetailHeader.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/StockDetailHeader.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
@@ -23,7 +24,9 @@ export const StockDetailHeader = ({
   loginStatus,
   isOwnerStock,
 }: StockDetailHeaderProps) => {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
+
   const [showModal, setShowModal] = useState(false);
   const [userStatus, setUserStatus] =
     useState<ModalMessage>('NOT_AUTHENTICATED');
@@ -40,11 +43,21 @@ export const StockDetailHeader = ({
   }, [isOwnerStock, loginStatus]);
 
   const { mutate: postStockUser } = usePostStockUser({
-    onSuccess: () => setUserStatus('OWNERSHIP'),
+    onSuccess: () => {
+      setUserStatus('OWNERSHIP');
+      queryClient.invalidateQueries({
+        queryKey: ['loginStatus', 'stockOwnership', stockId],
+      });
+    },
   });
 
   const { mutate: deleteStockUser } = useDeleteStockUser({
-    onSuccess: () => setUserStatus('NOT_OWNERSHIP'),
+    onSuccess: () => {
+      setUserStatus('NOT_OWNERSHIP');
+      queryClient.invalidateQueries({
+        queryKey: ['loginStatus', 'stockOwnership', stockId],
+      });
+    },
   });
 
   const handleModalConfirm = {

--- a/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
@@ -20,7 +20,7 @@ export const TextArea = ({ disabled, onSend, placeholder }: TextAreaProps) => {
   };
 
   return (
-    <>
+    <div className="flex flex-col">
       <form className="relative w-full" onSubmit={handleSubmit}>
         <textarea
           maxLength={100}
@@ -48,6 +48,6 @@ export const TextArea = ({ disabled, onSend, placeholder }: TextAreaProps) => {
       <span className={cn('display-medium12', inputCount > 100 && 'text-red')}>
         {inputCount}자/100자
       </span>
-    </>
+    </div>
   );
 };

--- a/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
@@ -1,11 +1,14 @@
 import { type FormEvent, useState } from 'react';
 import Send from '@/assets/send.svg?react';
+import { cn } from '@/utils/cn';
 
 interface TextAreaProps {
+  disabled: boolean;
   onSend: (text: string) => void;
+  placeholder: string;
 }
 
-export const TextArea = ({ onSend }: TextAreaProps) => {
+export const TextArea = ({ disabled, onSend, placeholder }: TextAreaProps) => {
   const [chatText, setChatText] = useState('');
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -15,15 +18,24 @@ export const TextArea = ({ onSend }: TextAreaProps) => {
   };
 
   return (
-    <form className="relative w-full" onSubmit={(e) => handleSubmit(e)}>
+    <form className="relative w-full" onSubmit={handleSubmit}>
       <textarea
         maxLength={100}
         value={chatText}
-        placeholder="주주 사용자만 입력 가능해요."
-        className="display-medium12 bg-light-yellow h-20 w-full resize-none rounded-md p-3 pr-10 focus:outline-none"
+        placeholder={placeholder}
+        disabled={disabled}
+        className={cn(
+          'display-medium12 bg-light-yellow h-20 w-full resize-none rounded-md p-3 pr-10 focus:outline-none',
+          disabled && 'cursor-not-allowed',
+        )}
         onChange={(e) => setChatText(e.target.value)}
       />
-      <button className="bg-orange absolute right-2 top-1/2 -translate-y-1/2 rounded p-1">
+      <button
+        className={cn(
+          'bg-orange absolute right-2 top-1/2 -translate-y-1/2 rounded p-1',
+          disabled && 'cursor-not-allowed',
+        )}
+      >
         <Send />
       </button>
     </form>

--- a/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
@@ -10,34 +10,44 @@ interface TextAreaProps {
 
 export const TextArea = ({ disabled, onSend, placeholder }: TextAreaProps) => {
   const [chatText, setChatText] = useState('');
+  const [inputCount, setInputCount] = useState(0);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSend(chatText);
     setChatText('');
+    setInputCount(0);
   };
 
   return (
-    <form className="relative w-full" onSubmit={handleSubmit}>
-      <textarea
-        maxLength={100}
-        value={chatText}
-        placeholder={placeholder}
-        disabled={disabled}
-        className={cn(
-          'display-medium12 bg-light-yellow h-20 w-full resize-none rounded-md p-3 pr-10 focus:outline-none',
-          disabled && 'cursor-not-allowed',
-        )}
-        onChange={(e) => setChatText(e.target.value)}
-      />
-      <button
-        className={cn(
-          'bg-orange absolute right-2 top-1/2 -translate-y-1/2 rounded p-1',
-          disabled && 'cursor-not-allowed',
-        )}
-      >
-        <Send />
-      </button>
-    </form>
+    <>
+      <form className="relative w-full" onSubmit={handleSubmit}>
+        <textarea
+          maxLength={100}
+          value={chatText}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={cn(
+            'display-medium12 border-light-yellow h-20 w-full resize-none rounded-md border-4 p-3 pr-10 focus:outline-none',
+            disabled && 'cursor-not-allowed',
+          )}
+          onChange={(e) => {
+            setChatText(e.target.value);
+            setInputCount(e.target.value.length);
+          }}
+        />
+        <button
+          className={cn(
+            'bg-orange absolute right-2 top-1/2 -translate-y-1/2 rounded p-2',
+            disabled && 'cursor-not-allowed',
+          )}
+        >
+          <Send />
+        </button>
+      </form>
+      <span className={cn('display-medium12', inputCount > 100 && 'text-red')}>
+        {inputCount}자/100자
+      </span>
+    </>
   );
 };

--- a/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
@@ -29,7 +29,7 @@ export const TextArea = ({ disabled, onSend, placeholder }: TextAreaProps) => {
           disabled={disabled}
           className={cn(
             'display-medium12 border-light-yellow h-20 w-full resize-none rounded-md border-4 p-3 pr-10 focus:outline-none',
-            disabled && 'cursor-not-allowed',
+            disabled && 'bg-light-gray/40 cursor-not-allowed',
           )}
           onChange={(e) => {
             setChatText(e.target.value);

--- a/packages/frontend/src/pages/stocks/StockRankingTable.tsx
+++ b/packages/frontend/src/pages/stocks/StockRankingTable.tsx
@@ -1,20 +1,16 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { usePostStockView } from '@/apis/queries/stock-detail';
-import {
-  type GetStockListRequest,
-  useGetStocksByPrice,
-} from '@/apis/queries/stocks';
+import { useGetStocksByPrice } from '@/apis/queries/stocks';
 import DownArrow from '@/assets/down-arrow.svg?react';
 import { cn } from '@/utils/cn';
 
 const LIMIT = 20;
 
 export const StockRankingTable = () => {
-  const [sortType, setSortType] =
-    useState<GetStockListRequest['sortType']>('increase');
+  const [sortType, setSortType] = useState<'increase' | 'decrease'>('increase');
 
-  const { data } = useGetStocksByPrice({ limit: LIMIT, sortType });
+  const { data } = useGetStocksByPrice({ limit: LIMIT });
   const { mutate } = usePostStockView();
 
   const handleSortType = () => {

--- a/packages/frontend/src/pages/stocks/StockRankingTable.tsx
+++ b/packages/frontend/src/pages/stocks/StockRankingTable.tsx
@@ -17,6 +17,13 @@ export const StockRankingTable = () => {
   const { data } = useGetStocksByPrice({ limit: LIMIT, sortType });
   const { mutate } = usePostStockView();
 
+  const handleSortType = () => {
+    setSortType((prev) => {
+      if (prev === 'increase') return 'decrease';
+      return 'increase';
+    });
+  };
+
   return (
     <div className="rounded-md bg-white px-6 shadow">
       <table className="w-full border-collapse">
@@ -38,12 +45,7 @@ export const StockRankingTable = () => {
                   'cursor-pointer',
                   sortType === 'increase' ? 'rotate-0' : 'rotate-180',
                 )}
-                onClick={() =>
-                  setSortType((prev) => {
-                    if (prev === 'increase') return 'decrease';
-                    return 'increase';
-                  })
-                }
+                onClick={handleSortType}
               />
             </th>
             <th className="text-right">거래대금</th>
@@ -51,7 +53,7 @@ export const StockRankingTable = () => {
           </tr>
         </thead>
         <tbody>
-          {data?.map((stock, index) => (
+          {data?.result.map((stock, index) => (
             <tr
               key={stock.id}
               className="display-medium14 text-dark-gray text-right [&>*]:p-4"
@@ -59,7 +61,7 @@ export const StockRankingTable = () => {
               <td className="flex gap-6 text-left">
                 <span className="text-gray w-3 flex-shrink-0">{index + 1}</span>
                 <Link
-                  to={`${stock.id}`}
+                  to={`/stocks/${stock.id}`}
                   onClick={() => mutate({ stockId: stock.id })}
                   className="display-bold14 hover:text-orange cursor-pointer text-ellipsis hover:underline"
                   aria-label={stock.name}

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -1,6 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
 import { Layout } from '@/components/layouts';
-import { Home } from '@/pages/home';
 import { Login } from '@/pages/login';
 import { MyPage } from '@/pages/my-page';
 import { StockDetail } from '@/pages/stock-detail';
@@ -14,10 +13,10 @@ export const router = createBrowserRouter([
         path: '/',
         element: <Stocks />,
       },
-      // {
-      //   path: '/stocks',
-      //   element: <Stocks />,
-      // },
+      {
+        path: '/stocks',
+        element: <Stocks />,
+      },
       {
         path: 'stocks/:stockId',
         element: <StockDetail />,

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -12,12 +12,12 @@ export const router = createBrowserRouter([
     children: [
       {
         path: '/',
-        element: <Home />,
-      },
-      {
-        path: '/stocks',
         element: <Stocks />,
       },
+      // {
+      //   path: '/stocks',
+      //   element: <Stocks />,
+      // },
       {
         path: 'stocks/:stockId',
         element: <StockDetail />,

--- a/packages/frontend/src/sockets/config.ts
+++ b/packages/frontend/src/sockets/config.ts
@@ -19,7 +19,7 @@ export const socketChat = ({ stockId, pageSize = 20 }: SocketChatType) => {
   });
 };
 
-// export const socketStock = io(`${URL}/api/stock/realtime`, {
-//   transports: ['websocket'],
-//   reconnectionDelayMax: 10000,
-// });
+export const socketStock = io(`${URL}/api/stock/realtime`, {
+  transports: ['websocket'],
+  reconnectionDelayMax: 10000,
+});

--- a/packages/frontend/src/sockets/schema.ts
+++ b/packages/frontend/src/sockets/schema.ts
@@ -5,9 +5,10 @@ export const ChatDataSchema = z.object({
   likeCount: z.number(),
   message: z.string(),
   type: z.string(),
-  createdAt: z.date(),
+  createdAt: z.string().datetime(),
   liked: z.boolean(),
   nickname: z.string(),
+  mentioned: z.boolean(),
 });
 
 export type ChatData = z.infer<typeof ChatDataSchema>;
@@ -18,3 +19,13 @@ export const ChatDataResponseSchema = z.object({
 });
 
 export type ChatDataResponse = z.infer<typeof ChatDataResponseSchema>;
+
+export const ChatLikeSchema = z.object({
+  stockId: z.string(),
+  chatId: z.number(),
+  likeCount: z.number(),
+  message: z.string(),
+  date: z.string().datetime(),
+});
+
+export type ChatLikeResponse = z.infer<typeof ChatLikeSchema>;


### PR DESCRIPTION
close #107 #96 #95 #94 #97 

## ✅ 작업 내용

- **채팅 기능 구현**
  - 로그인 안한 사용자 || 주식 미소유
    - 채팅 전송 불가
    - 좋아요 불가
    - 미리보기 3개 확인 가능(나머지 블러처리), 만약에 채팅이 3개 이하면 전부 블러처리
  - 주식 소유
    - 채팅 전송 및 좋아요 가능
  - 채팅 입력 100자 제한
  - 소켓 연결 상태에 따라 접속 중/연결 끊김 상태 표시
  - 웹소켓 사용해서 좋아요/채팅 내역 실시간 반영
  - 자신의 채팅은 색상 다르게 표시
- **주식 상세 페이지 반응형 구현**
- **주식 소유/삭제 시 바로 업데이트 되지 않는 문제 해결**

## 📸 스크린샷(FE만)

**로그인 X || 주식미소유**
![image](https://github.com/user-attachments/assets/1a3cf073-670e-41ec-9a2b-380f51e96c55)

**주식 소유**
![image](https://github.com/user-attachments/assets/282f4c8f-f6c5-4a86-b196-56f1207fe0ab)

**반응형**


https://github.com/user-attachments/assets/0514f9f8-a13e-4580-b8fc-8f992c276ebb



## 📌 이슈 사항

- 채팅 무한스크롤/정렬 기능 구현 필요

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
