### PR TITLE
Feature/#277 - 요청제어 큐 적용

### DIFF
--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -43,8 +43,12 @@ export class AuthController {
   async user(@Req() request: Request) {
     if (request.user) {
       const user = request.user as User;
-      return { message: 'Authenticated', nickname: user.nickname };
+      return {
+        message: 'Authenticated',
+        nickname: user.nickname,
+        subName: user.subName,
+      };
     }
-    return { message: 'Not Authenticated', nickname: null };
+    return { message: 'Not Authenticated', nickname: null, subName: null };
   }
 }

--- a/packages/backend/src/chat/dto/chat.response.ts
+++ b/packages/backend/src/chat/dto/chat.response.ts
@@ -31,6 +31,8 @@ export class ChatScrollResponse {
         type: ChatType.NORMAL,
         isLiked: true,
         createdAt: new Date(),
+        mentioned: false,
+        subName: '0001',
       },
     ],
   })
@@ -46,6 +48,7 @@ export class ChatScrollResponse {
       liked: !!(chat.likes && chat.likes.length > 0),
       mentioned: chat.mentions && chat.mentions.length > 0,
       nickname: chat.user.nickname,
+      subName: chat.user.subName,
     }));
     this.hasMore = hasMore;
   }

--- a/packages/backend/src/chat/dto/chat.response.ts
+++ b/packages/backend/src/chat/dto/chat.response.ts
@@ -2,13 +2,14 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Chat } from '@/chat/domain/chat.entity';
 import { ChatType } from '@/chat/domain/chatType.enum';
 
-interface ChatResponse {
+export interface ChatResponse {
   id: number;
   likeCount: number;
   message: string;
   type: string;
   liked: boolean;
   nickname: string;
+  subName: string;
   mentioned: boolean;
   createdAt: Date;
 }

--- a/packages/backend/src/scraper/openapi/api/openapiFluctuationData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiFluctuationData.api.ts
@@ -2,17 +2,15 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { DataSource, EntityManager } from 'typeorm';
 import { Logger } from 'winston';
-import { OpenapiTokenApi } from '@/scraper/openapi/api/openapiToken.api';
 import {
   DECREASE_STOCK_QUERY,
   INCREASE_STOCK_QUERY,
 } from '@/scraper/openapi/constants/query';
 import { TR_IDS } from '@/scraper/openapi/type/openapiUtil.type';
-import { getOpenApi } from '@/scraper/openapi/util/openapiUtil.api';
 import { FluctuationRankStock } from '@/stock/domain/FluctuationRankStock.entity';
 import { Stock } from '@/stock/domain/stock.entity';
-import { StockLiveData } from '@/stock/domain/stockLiveData.entity';
 import { Json, OpenapiQueue } from '@/scraper/openapi/queue/openapi.queue';
+import { OpenapiLiveData } from '@/scraper/openapi/api/openapiLiveData.api';
 
 @Injectable()
 export class OpenapiFluctuationData {
@@ -20,9 +18,9 @@ export class OpenapiFluctuationData {
     '/uapi/domestic-stock/v1/ranking/fluctuation';
   private readonly liveUrl = '/uapi/domestic-stock/v1/quotations/inquire-price';
   constructor(
-    private readonly openApiToken: OpenapiTokenApi,
     private readonly datasource: DataSource,
     private readonly openApiQueue: OpenapiQueue,
+    private readonly openApiLive: OpenapiLiveData,
     @Inject('winston') private readonly logger: Logger,
   ) {
     setTimeout(() => this.getFluctuationRankStocks(), 1000);
@@ -35,96 +33,55 @@ export class OpenapiFluctuationData {
     await this.getFluctuationRankFromApi(false);
   }
 
-  async getDecreaseRankStocks(count = 5) {
-    try {
-      if (count === 0) return;
-      const result = await this.getFluctuationRankApiStocks(false);
-      const liveResult = await this.getFluctuationRankApiLive(result);
-      await this.datasource.transaction(async (manager) => {
-        await this.datasource.manager.delete(FluctuationRankStock, {
-          isRising: false,
-        });
-        await this.saveFluctuationRankStocks(result, manager);
-        await this.saveLiveData(liveResult, manager);
-        this.logger.info('decrease rank stocks updated');
-      });
-    } catch (error) {
-      this.logger.warn(error);
-      await new Promise((resolve) =>
-        setTimeout(() => resolve(this.getDecreaseRankStocks(--count)), 2000),
-      );
-    }
-  }
-
-  async getIncreaseRankStocks(count = 5) {
-    try {
-      if (count === 0) return;
-      const result = await this.getFluctuationRankApiStocks(true);
-      const liveResult = await this.getFluctuationRankApiLive(result);
-      await this.datasource.transaction(async (manager) => {
-        await this.datasource.manager.delete(FluctuationRankStock, {
-          isRising: true,
-        });
-        await this.saveFluctuationRankStocks(result, manager);
-        await this.saveLiveData(liveResult, manager);
-        this.logger.info('increase rank stocks updated');
-      });
-    } catch (error) {
-      this.logger.warn(error);
-      await new Promise((resolve) =>
-        setTimeout(() => resolve(this.getIncreaseRankStocks(--count)), 3000),
-      );
-    }
-  }
-
-  private async getFluctuationRankFromApi(isRising: boolean) {
+  async getFluctuationRankFromApi(isRising: boolean) {
     const query = isRising ? INCREASE_STOCK_QUERY : DECREASE_STOCK_QUERY;
-    const callback: <T extends Json>(value: T) => Promise<void> = async (
-      data: Json,
-    ) => {
-      if (!Array.isArray(data.output)) return;
-      const save = data.output
-        .slice(0, 20)
-        .map((result: Record<string, string>) => ({
-          rank: Number(result.data_rank),
-          fluctuationRate: result.prdy_ctrt,
-          stock: { id: result.stck_shrn_iscd } as Stock,
-          isRising,
-        }));
-      await this.saveFluctuationRankStocks(save, this.datasource.manager);
-
-      save.forEach((data) => {
-        const stockId = data.stock.id;
-        const callback: <T extends Json>(value: T) => Promise<void> = async (
-          data: Json,
-        ) => {
-          if (Array.isArray(data.output)) return;
-          const stockLiveData = this.convertToStockLiveData(
-            data.output,
-            stockId,
-          );
-          await this.saveIndividualLiveData(
-            stockLiveData,
-            this.datasource.manager,
-          );
-        };
-        this.openApiQueue.enqueue({
-          url: this.liveUrl,
-          query: {
-            fid_cond_mrkt_div_code: 'J',
-            fid_input_iscd: stockId,
-          },
-          trId: TR_IDS.LIVE_DATA,
-          callback,
-        });
-      });
-    };
-
     this.openApiQueue.enqueue({
       url: this.fluctuationUrl,
       query,
       trId: TR_IDS.FLUCTUATION_DATA,
-      callback,
+      callback: this.getFluctuationRankStocksCallback(isRising),
+    });
+  }
+
+  private getFluctuationRankStocksCallback(isRising: boolean) {
+    return async (data: Json) => {
+      const save = this.convertToFluctuationRankStock(data, isRising);
+      await this.saveFluctuationRankStocks(save, this.datasource.manager);
+
+      save.forEach((data) => {
+        const stockId = data.stock.id;
+        this.insertLiveDataRequest(stockId);
+      });
+    };
+  }
+
+  private convertToFluctuationRankStock(data: Json, isRising: boolean) {
+    if (!Array.isArray(data.output))
+      return [
+        {
+          rank: Number(data.output.data_rank),
+          fluctuationRate: data.output.prdy_ctrt,
+          stock: { id: data.output.stck_shrn_iscd } as Stock,
+          isRising,
+        },
+      ];
+    return data.output.slice(0, 20).map((result: Record<string, string>) => ({
+      rank: Number(result.data_rank),
+      fluctuationRate: result.prdy_ctrt,
+      stock: { id: result.stck_shrn_iscd } as Stock,
+      isRising,
+    }));
+  }
+
+  private insertLiveDataRequest(stockId: string) {
+    this.openApiQueue.enqueue({
+      url: this.liveUrl,
+      query: {
+        fid_cond_mrkt_div_code: 'J',
+        fid_input_iscd: stockId,
+      },
+      trId: TR_IDS.LIVE_DATA,
+      callback: this.openApiLive.getLiveDataSaveCallback(stockId),
     });
   }
 
@@ -138,102 +95,6 @@ export class OpenapiFluctuationData {
       .insert()
       .into(FluctuationRankStock)
       .values(result)
-      .execute();
-  }
-
-  private async saveLiveData(data: StockLiveData[], manager: EntityManager) {
-    return await manager
-      .getRepository(StockLiveData)
-      .createQueryBuilder()
-      .insert()
-      .into(StockLiveData)
-      .values(data)
-      .orUpdate(
-        ['current_price', 'change_rate', 'volume', 'high', 'low', 'open'],
-        ['stock_id'],
-      )
-      .execute();
-  }
-
-  private async getFluctuationRankApiStocks(isRising: boolean) {
-    const query = isRising ? INCREASE_STOCK_QUERY : DECREASE_STOCK_QUERY;
-
-    const result = await getOpenApi(
-      this.fluctuationUrl,
-      (await this.openApiToken.configs())[0],
-      query,
-      TR_IDS.FLUCTUATION_DATA,
-    );
-
-    return result.output.slice(0, 20).map((result: Record<string, string>) => {
-      return {
-        rank: result.data_rank,
-        fluctuationRate: result.prdy_ctrt,
-        stock: { id: result.stck_shrn_iscd },
-        isRising,
-      };
-    });
-  }
-
-  private async getFluctuationRankApiLive(data: FluctuationRankStock[]) {
-    const result: StockLiveData[] = [];
-    for (let i = 0; i < 20; ++i) {
-      if (i >= data.length) break;
-      else if (i == 10)
-        await new Promise((resolve) => setTimeout(resolve, 1500));
-      const stockId = data[i].stock.id;
-      const stockData = await getOpenApi(
-        this.liveUrl,
-        (await this.openApiToken.configs())[0],
-        {
-          fid_cond_mrkt_div_code: 'J',
-          fid_input_iscd: stockId,
-        },
-        TR_IDS.LIVE_DATA,
-      );
-      result.push(this.convertToStockLiveData(stockData.output, stockId));
-    }
-    return result;
-  }
-
-  private convertToStockLiveData(
-    stockData: Record<string, string>,
-    stockId: string,
-  ): StockLiveData {
-    const stockLiveData = new StockLiveData();
-    stockLiveData.stock = { id: stockId } as Stock;
-    stockLiveData.currentPrice = parseFloat(stockData.stck_prpr);
-    stockLiveData.changeRate = parseFloat(stockData.prdy_ctrt);
-    stockLiveData.volume = parseInt(stockData.acml_vol);
-    stockLiveData.high = parseFloat(stockData.stck_hgpr);
-    stockLiveData.low = parseFloat(stockData.stck_lwpr);
-    stockLiveData.open = parseFloat(stockData.stck_oprc);
-    stockLiveData.updatedAt = new Date();
-    return stockLiveData;
-  }
-
-  private async saveIndividualLiveData(
-    data: StockLiveData,
-    manager: EntityManager,
-  ) {
-    return await manager
-      .getRepository(StockLiveData)
-      .createQueryBuilder()
-      .insert()
-      .into(StockLiveData)
-      .values(data)
-      .orUpdate(
-        [
-          'current_price',
-          'change_rate',
-          'volume',
-          'high',
-          'low',
-          'open',
-          'updatedAt',
-        ],
-        ['stock_id'],
-      )
       .execute();
   }
 }

--- a/packages/backend/src/scraper/openapi/api/openapiFluctuationData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiFluctuationData.api.ts
@@ -35,6 +35,7 @@ export class OpenapiFluctuationData {
 
   async getFluctuationRankFromApi(isRising: boolean) {
     const query = isRising ? INCREASE_STOCK_QUERY : DECREASE_STOCK_QUERY;
+    await this.datasource.manager.delete(FluctuationRankStock, { isRising });
     this.openApiQueue.enqueue({
       url: this.fluctuationUrl,
       query,

--- a/packages/backend/src/scraper/openapi/api/openapiLiveData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiLiveData.api.ts
@@ -7,6 +7,7 @@ import { TR_IDS } from '../type/openapiUtil.type';
 import { getOpenApi } from '../util/openapiUtil.api';
 import { Stock } from '@/stock/domain/stock.entity';
 import { StockLiveData } from '@/stock/domain/stockLiveData.entity';
+import { Json } from '@/scraper/openapi/queue/openapi.queue';
 
 @Injectable()
 export class OpenapiLiveData {
@@ -92,10 +93,56 @@ export class OpenapiLiveData {
     }
   }
 
+  getLiveDataSaveCallback(stockId: string) {
+    return async (data: Json) => {
+      if (Array.isArray(data.output)) return;
+      const stockLiveData = this.convertToStockLiveData(data.output, stockId);
+      await this.saveIndividualLiveData(stockLiveData);
+    };
+  }
+
   private makeLiveDataQuery(stockId: string, code: 'J' = 'J') {
     return {
       fid_cond_mrkt_div_code: code,
       fid_input_iscd: stockId,
     };
+  }
+
+  private convertToStockLiveData(
+    stockData: Record<string, string>,
+    stockId: string,
+  ): StockLiveData {
+    const stockLiveData = new StockLiveData();
+    stockLiveData.stock = { id: stockId } as Stock;
+    stockLiveData.currentPrice = parseFloat(stockData.stck_prpr);
+    stockLiveData.changeRate = parseFloat(stockData.prdy_ctrt);
+    stockLiveData.volume = parseInt(stockData.acml_vol);
+    stockLiveData.high = parseFloat(stockData.stck_hgpr);
+    stockLiveData.low = parseFloat(stockData.stck_lwpr);
+    stockLiveData.open = parseFloat(stockData.stck_oprc);
+    stockLiveData.updatedAt = new Date();
+    return stockLiveData;
+  }
+
+  private async saveIndividualLiveData(data: StockLiveData) {
+    return await this.datasource.manager
+      .getRepository(StockLiveData)
+      .createQueryBuilder()
+      .insert()
+      .into(StockLiveData)
+      .values(data)
+      .orUpdate(
+        [
+          'current_price',
+          'change_rate',
+          'volume',
+          'high',
+          'low',
+          'open',
+          'updatedAt',
+        ],
+        ['stock_id'],
+      )
+      .execute();
   }
 }

--- a/packages/backend/src/scraper/openapi/api/openapiLiveData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiLiveData.api.ts
@@ -54,7 +54,6 @@ export class OpenapiLiveData {
       stockLiveData.low = parseFloat(data.stck_lwpr);
       stockLiveData.open = parseFloat(data.stck_oprc);
       stockLiveData.updatedAt = new Date();
-
       return stockLiveData;
     }
   };

--- a/packages/backend/src/scraper/openapi/api/openapiRankView.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiRankView.api.ts
@@ -45,6 +45,7 @@ export class OpenapiRankViewApi {
       const callback: <T extends Json>(value: T) => Promise<void> = async (
         liveResult: Json,
       ) => {
+        if (Array.isArray(liveResult.output)) return;
         const data = this.convertToStockLiveData(liveResult.output, stock.id);
         await this.saveIndividualLiveData(data, this.datasource.manager);
       };

--- a/packages/backend/src/scraper/openapi/api/openapiRankView.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiRankView.api.ts
@@ -1,13 +1,10 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
-import { DataSource, EntityManager } from 'typeorm';
-import { Logger } from 'winston';
-import { OpenapiTokenApi } from '@/scraper/openapi/api/openapiToken.api';
-import { Json, OpenapiQueue } from '@/scraper/openapi/queue/openapi.queue';
+import { DataSource } from 'typeorm';
+import { OpenapiQueue } from '@/scraper/openapi/queue/openapi.queue';
 import { TR_IDS } from '@/scraper/openapi/type/openapiUtil.type';
-import { getOpenApi } from '@/scraper/openapi/util/openapiUtil.api';
 import { Stock } from '@/stock/domain/stock.entity';
-import { StockLiveData } from '@/stock/domain/stockLiveData.entity';
+import { OpenapiLiveData } from '@/scraper/openapi/api/openapiLiveData.api';
 
 @Injectable()
 export class OpenapiRankViewApi {
@@ -15,40 +12,16 @@ export class OpenapiRankViewApi {
 
   constructor(
     private readonly datasource: DataSource,
-    private readonly openApiToken: OpenapiTokenApi,
+    private readonly openApiLiveData: OpenapiLiveData,
     private readonly openApiQueue: OpenapiQueue,
-    @Inject('winston') private readonly logger: Logger,
   ) {
     setTimeout(() => this.getTopViewsStockLiveData(), 6000);
   }
 
   @Cron('* 9-15 * * 1-5')
-  async getTopViewsStockLiveData(count = 5) {
-    try {
-      if (count === 0) return;
-      await this.getTopViewsStocks();
-      // const liveResult = await this.getFluctuationRankApiLive(topViewsStocks);
-    } catch (error) {
-      this.logger.warn(error);
-      this.getTopViewsStockLiveData(--count);
-    }
-  }
-
-  private async getTopViewsStocks() {
-    const date = await this.datasource.manager
-      .getRepository(Stock)
-      .createQueryBuilder('stock')
-      .orderBy('stock.views', 'DESC')
-      .limit(10)
-      .getMany();
+  async getTopViewsStockLiveData() {
+    const date = await this.findTopViewsStocks();
     date.forEach((stock) => {
-      const callback: <T extends Json>(value: T) => Promise<void> = async (
-        liveResult: Json,
-      ) => {
-        if (Array.isArray(liveResult.output)) return;
-        const data = this.convertToStockLiveData(liveResult.output, stock.id);
-        await this.saveIndividualLiveData(data, this.datasource.manager);
-      };
       this.openApiQueue.enqueue({
         url: this.liveUrl,
         query: {
@@ -56,93 +29,17 @@ export class OpenapiRankViewApi {
           fid_input_iscd: stock.id,
         },
         trId: TR_IDS.LIVE_DATA,
-        callback,
+        callback: this.openApiLiveData.getLiveDataSaveCallback(stock.id),
       });
     });
-    return date.slice(0, 10);
   }
 
-  private async getViewsRankApiLive(data: Stock[]) {
-    const result: StockLiveData[] = [];
-    for (let i = 0; i < 20; ++i) {
-      if (i >= data.length) break;
-      else if (i == 10)
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      const stockId = data[i].id;
-      const stockData = await getOpenApi(
-        this.liveUrl,
-        (await this.openApiToken.configs())[0],
-        {
-          fid_cond_mrkt_div_code: 'J',
-          fid_input_iscd: stockId,
-        },
-        TR_IDS.LIVE_DATA,
-      );
-      result.push(this.convertToStockLiveData(stockData.output, stockId));
-    }
-    return result;
-  }
-
-  private async saveLiveData(data: StockLiveData[], manager: EntityManager) {
-    return await manager
-      .getRepository(StockLiveData)
-      .createQueryBuilder()
-      .insert()
-      .into(StockLiveData)
-      .values(data)
-      .orUpdate(
-        [
-          'current_price',
-          'change_rate',
-          'volume',
-          'high',
-          'low',
-          'open',
-          'updated_at',
-        ],
-        ['stock_id'],
-      )
-      .execute();
-  }
-
-  private async saveIndividualLiveData(
-    data: StockLiveData,
-    manager: EntityManager,
-  ) {
-    return await manager
-      .getRepository(StockLiveData)
-      .createQueryBuilder()
-      .insert()
-      .into(StockLiveData)
-      .values(data)
-      .orUpdate(
-        [
-          'current_price',
-          'change_rate',
-          'volume',
-          'high',
-          'low',
-          'open',
-          'updatedAt',
-        ],
-        ['stock_id'],
-      )
-      .execute();
-  }
-
-  private convertToStockLiveData(
-    stockData: Record<string, string>,
-    stockId: string,
-  ): StockLiveData {
-    const stockLiveData = new StockLiveData();
-    stockLiveData.stock = { id: stockId } as Stock;
-    stockLiveData.currentPrice = parseFloat(stockData.stck_prpr);
-    stockLiveData.changeRate = parseFloat(stockData.prdy_ctrt);
-    stockLiveData.volume = parseInt(stockData.acml_vol);
-    stockLiveData.high = parseFloat(stockData.stck_hgpr);
-    stockLiveData.low = parseFloat(stockData.stck_lwpr);
-    stockLiveData.open = parseFloat(stockData.stck_oprc);
-    stockLiveData.updatedAt = new Date();
-    return stockLiveData;
+  private async findTopViewsStocks() {
+    return await this.datasource.manager
+      .getRepository(Stock)
+      .createQueryBuilder('stock')
+      .orderBy('stock.views', 'DESC')
+      .limit(10)
+      .getMany();
   }
 }

--- a/packages/backend/src/scraper/openapi/queue/openapi.queue.ts
+++ b/packages/backend/src/scraper/openapi/queue/openapi.queue.ts
@@ -5,9 +5,9 @@ import { TR_ID } from '@/scraper/openapi/type/openapiUtil.type';
 import { getOpenApi } from '@/scraper/openapi/util/openapiUtil.api';
 import { PriorityQueue } from '@/scraper/openapi/util/priorityQueue';
 
-export type Json = {
-  output: Record<string, string>;
-};
+export interface Json {
+  output: Record<string, string> | Record<string, string>[];
+}
 
 export interface OpenapiQueueNodeValue {
   url: string;

--- a/packages/backend/src/scraper/openapi/queue/openapi.queue.ts
+++ b/packages/backend/src/scraper/openapi/queue/openapi.queue.ts
@@ -59,17 +59,27 @@ export class OpenapiConsumer {
     if (this.isProcessing) {
       return;
     }
-    const maxTokenIndex = (await this.openapiTokenApi.configs()).length;
+
     while (!this.queue.isEmpty()) {
       this.isProcessing = true;
-      await this.processRequest();
-      this.currentTokenIndex = (this.currentTokenIndex + 1) % maxTokenIndex;
+      await this.processQueueRequest();
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     this.isProcessing = false;
   }
 
-  private async processRequest() {
+  private async processQueueRequest() {
+    const tokenCount = (await this.openapiTokenApi.configs()).length;
+    for (let i = 0; i < tokenCount; i++) {
+      await this.processIndividualTokenRequest(this.currentTokenIndex);
+      if (!this.isProcessing) {
+        return;
+      }
+      this.currentTokenIndex = (this.currentTokenIndex + 1) % tokenCount;
+    }
+  }
+
+  private async processIndividualTokenRequest(index: number) {
     for (let i = 0; i < this.REQUEST_COUNT_PER_SECOND; i++) {
       const node = this.queue.dequeue();
       if (!node) {
@@ -78,7 +88,7 @@ export class OpenapiConsumer {
       try {
         const data = await getOpenApi(
           node.url,
-          (await this.openapiTokenApi.configs())[this.currentTokenIndex],
+          (await this.openapiTokenApi.configs())[index],
           node.query,
           node.trId,
         );

--- a/packages/backend/src/stock/dto/stock.response.ts
+++ b/packages/backend/src/stock/dto/stock.response.ts
@@ -147,9 +147,19 @@ export class StockRankResponse {
     example: 1,
   })
   rank: number;
+
+  @ApiProperty({
+    description: '상승 하락 여부',
+    example: true,
+  })
+  isRising: boolean;
 }
 
 export class StockRankResponses {
+  @ApiProperty({
+    description: '주식 랭킹 결과',
+    type: [StockRankResponse],
+  })
   result: StockRankResponse[];
 
   constructor(stocks: Record<string, string>[]) {
@@ -161,6 +171,7 @@ export class StockRankResponses {
       marketCap: stock.marketCap,
       changeRate: parseFloat(stock.rank_fluctuation_rate),
       rank: parseInt(stock.rank_rank),
+      isRising: Number(stock.rank_isRising) === 1,
     }));
   }
 }

--- a/packages/backend/src/stock/stock.controller.ts
+++ b/packages/backend/src/stock/stock.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { Request } from 'express';
 import { ApiGetStocks, LimitQuery } from './decorator/stock.decorator';
@@ -36,6 +37,7 @@ import { GetUser } from '@/common/decorator/user.decorator';
 import { sessionConfig } from '@/configs/session.config';
 import { StockSearchRequest } from '@/stock/dto/stock.request';
 import {
+  StockRankResponses,
   StockSearchResponse,
   StockViewsResponse,
 } from '@/stock/dto/stock.response';
@@ -60,6 +62,15 @@ const TIME_UNIT = {
 } as const;
 
 type TIME_UNIT = (typeof TIME_UNIT)[keyof typeof TIME_UNIT];
+
+const FLUCTUATION_TYPE = {
+  INCREASE: 'increase',
+  DECREASE: 'decrease',
+  ALL: 'all',
+} as const;
+
+type FLUCTUATION_TYPE =
+  (typeof FLUCTUATION_TYPE)[keyof typeof FLUCTUATION_TYPE];
 
 @Controller('stock')
 export class StockController {
@@ -211,9 +222,36 @@ export class StockController {
   }
 
   @Get('fluctuation')
-  @ApiGetStocks('가격 상승률, 하락률 기반 주식 리스트 조회 API')
-  async getTopStocksByFluctuation() {
-    return await this.stockService.getTopStocksByFluctuation();
+  @ApiOperation({
+    summary: '등가, 등락률 기반 주식 리스트 조회 API',
+    description: '등가, 등락률 기반 주식 리스트를 조회합니다',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description:
+      '조회할 리스트 수(기본값: 20, 등가, 등락 모두 받으면 모든 데이터 전송)',
+  })
+  @ApiQuery({
+    name: 'type',
+    required: false,
+    description: '데이터 타입(기본값: increase, all, increase, decrease)',
+    enum: ['increase', 'decrease', 'all'],
+  })
+  @ApiOkResponse({
+    description: '',
+    type: [StockRankResponses],
+  })
+  async getTopStocksByFluctuation(
+    @LimitQuery(20) limit: number,
+    @Query('type') type: FLUCTUATION_TYPE,
+  ) {
+    if (type === FLUCTUATION_TYPE.DECREASE) {
+      return await this.stockService.getTopStocksByLosers(limit);
+    } else if (type === FLUCTUATION_TYPE.ALL) {
+      return await this.stockService.getTopStocksByFluctuation();
+    }
+    return await this.stockService.getTopStocksByGainers(limit);
   }
 
   @ApiOperation({


### PR DESCRIPTION
close #277 

## ✅ 작업 내용
- 변동률, 라이브, 조회수 주식에 데이터에 대해 요청 제어 큐 적용
- 채팅 서브네임 필드 추가
- 큐가 모든 계좌에 대하여 적절하게 분배할 수 있도록 변경
## 🟢 완료 조건
- DB와 logger를 통해 확인
- postman으로 응답 확인

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
