### PR TITLE
Feature/#182 - 메인페이지 데이터 패칭 수정, 마이페이지 구현

### DIFF
--- a/packages/frontend/src/apis/queries/auth/schema.ts
+++ b/packages/frontend/src/apis/queries/auth/schema.ts
@@ -36,3 +36,20 @@ export const PostLogoutSchema = z.object({
 });
 
 export type PostLogout = z.infer<typeof PostLogoutSchema>;
+
+export const GetUserStockSchema = z.object({
+  id: z.number(),
+  stockId: z.string(),
+  name: z.string(),
+  isTrading: z.boolean(),
+  groupCode: z.string(),
+  createdAt: z.string().datetime(),
+});
+
+export type GetUserStock = z.infer<typeof GetUserStockSchema>;
+
+export const GetUserStockResponseSchema = z.object({
+  userStocks: z.array(GetUserStockSchema),
+});
+
+export type GetUserStockResponse = z.infer<typeof GetUserStockResponseSchema>;

--- a/packages/frontend/src/apis/queries/auth/schema.ts
+++ b/packages/frontend/src/apis/queries/auth/schema.ts
@@ -13,3 +13,20 @@ export const GetTestLoginSchema = z.object({
 });
 
 export type GetTestLogin = z.infer<typeof GetTestLoginSchema>;
+
+export const GetUserInfoSchema = z.object({
+  nickname: z.string(),
+  subName: z.string(),
+  createdAt: z.string().datetime(),
+  email: z.string(),
+  type: z.string(),
+});
+
+export type GetUserInfo = z.infer<typeof GetUserInfoSchema>;
+
+export const PostUserNicknameSchema = z.object({
+  message: z.string(),
+  date: z.string().datetime(),
+});
+
+export type PostUserNickname = z.infer<typeof PostUserNicknameSchema>;

--- a/packages/frontend/src/apis/queries/auth/schema.ts
+++ b/packages/frontend/src/apis/queries/auth/schema.ts
@@ -30,3 +30,9 @@ export const PostUserNicknameSchema = z.object({
 });
 
 export type PostUserNickname = z.infer<typeof PostUserNicknameSchema>;
+
+export const PostLogoutSchema = z.object({
+  message: z.string(),
+});
+
+export type PostLogout = z.infer<typeof PostLogoutSchema>;

--- a/packages/frontend/src/apis/queries/auth/useGetUserInfo.ts
+++ b/packages/frontend/src/apis/queries/auth/useGetUserInfo.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetUserInfoSchema, type GetUserInfo } from './schema';
+import { get } from '@/apis/utils/get';
+
+const getUserInfo = () =>
+  get<GetUserInfo>({
+    schema: GetUserInfoSchema,
+    url: '/api/user/info',
+  });
+
+export const useGetUserInfo = () => {
+  return useQuery({
+    queryKey: ['userInfo'],
+    queryFn: getUserInfo,
+  });
+};

--- a/packages/frontend/src/apis/queries/auth/useGetUserStock.ts
+++ b/packages/frontend/src/apis/queries/auth/useGetUserStock.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  GetUserStockResponseSchema,
+  type GetUserStockResponse,
+} from './schema';
+import { get } from '@/apis/utils/get';
+
+const getUserStock = () =>
+  get<GetUserStockResponse>({
+    schema: GetUserStockResponseSchema,
+    url: '/api/stock/user',
+  });
+
+export const useGetUserStock = () => {
+  return useQuery({
+    queryKey: ['userStock'],
+    queryFn: getUserStock,
+  });
+};

--- a/packages/frontend/src/apis/queries/auth/usePostLogout.ts
+++ b/packages/frontend/src/apis/queries/auth/usePostLogout.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import { PostLogout, PostLogoutSchema } from './schema';
+import { post } from '@/apis/utils/post';
+
+const postLogout = () =>
+  post<PostLogout>({
+    schema: PostLogoutSchema,
+    url: '/api/auth/logout',
+  });
+
+export const usePostLogout = () => {
+  return useMutation({
+    mutationKey: ['logout'],
+    mutationFn: postLogout,
+  });
+};

--- a/packages/frontend/src/apis/queries/auth/usePostUserNickname.ts
+++ b/packages/frontend/src/apis/queries/auth/usePostUserNickname.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { PostUserNickname, PostUserNicknameSchema } from './schema';
+import { post } from '@/apis/utils/post';
+
+const postUserNickname = ({ nickname }: { nickname: string }) =>
+  post<PostUserNickname>({
+    params: { nickname },
+    schema: PostUserNicknameSchema,
+    url: '/api/user/info',
+  });
+
+export const usePostUserNickname = ({ nickname }: { nickname: string }) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['userNickname'],
+    mutationFn: () => postUserNickname({ nickname }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userInfo'] });
+    },
+  });
+};

--- a/packages/frontend/src/apis/queries/stock-detail/useDeleteStockUser.ts
+++ b/packages/frontend/src/apis/queries/stock-detail/useDeleteStockUser.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import {
   DeleteStockUserSchema,
   type DeleteStockUserRequest,
@@ -13,7 +13,9 @@ const deleteStockUser = ({ stockId }: DeleteStockUserRequest) =>
     data: { stockId },
   });
 
-export const useDeleteStockUser = ({ ...options }) => {
+export const useDeleteStockUser = (
+  options?: UseMutationOptions<DeleteStockUser, Error, DeleteStockUserRequest>,
+) => {
   return useMutation({
     mutationKey: ['deleteStockUser'],
     mutationFn: ({ stockId }: DeleteStockUserRequest) =>

--- a/packages/frontend/src/apis/queries/stocks/schema.ts
+++ b/packages/frontend/src/apis/queries/stocks/schema.ts
@@ -67,3 +67,16 @@ export const SearchResultsResponseSchema = z.object({
 });
 
 export type SearchResultsResponse = z.infer<typeof SearchResultsResponseSchema>;
+
+export const StockIndexSchema = z.object({
+  name: z.string(),
+  currentPrice: z.string(),
+  changeRate: z.string(),
+  volume: z.number(),
+  high: z.string(),
+  low: z.string(),
+  open: z.string(),
+  updatedAt: z.string().datetime(),
+});
+
+export type StockIndexResponse = z.infer<typeof StockIndexSchema>;

--- a/packages/frontend/src/apis/queries/stocks/useGetStockIndex.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetStockIndex.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+import { StockIndexSchema, type StockIndexResponse } from './schema';
+import { get } from '@/apis/utils/get';
+
+const getStockIndex = () =>
+  get<StockIndexResponse[]>({
+    schema: z.array(StockIndexSchema),
+    url: `/api/stock/index`,
+  });
+
+export const useGetStockIndex = () => {
+  return useQuery({
+    queryKey: ['stockIndex'],
+    queryFn: getStockIndex,
+  });
+};

--- a/packages/frontend/src/apis/queries/stocks/useGetTopViews.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetTopViews.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
 import {
   GetStockListResponseSchema,
   GetStockTopViewsResponse,
@@ -7,8 +8,8 @@ import {
 import { get } from '@/apis/utils/get';
 
 const getTopViews = ({ limit }: Partial<GetStockListRequest>) =>
-  get<GetStockTopViewsResponse[]>({
-    schema: GetStockListResponseSchema,
+  get<Partial<GetStockTopViewsResponse>[]>({
+    schema: z.array(GetStockListResponseSchema.partial()),
     url: `/api/stock/topViews`,
     params: { limit },
   });

--- a/packages/frontend/src/apis/utils/post.ts
+++ b/packages/frontend/src/apis/utils/post.ts
@@ -4,7 +4,7 @@ import { instance } from '../config';
 import { formatZodError } from './formatZodError';
 
 interface PostParams {
-  params: AxiosRequestConfig['params'];
+  params?: AxiosRequestConfig['params'];
   schema: z.ZodType;
   url: string;
 }

--- a/packages/frontend/src/components/layouts/Layout.tsx
+++ b/packages/frontend/src/components/layouts/Layout.tsx
@@ -6,7 +6,7 @@ export const Layout = () => {
     <div className="flex min-h-screen">
       <Sidebar />
       <main className="ml-20 flex-1">
-        <div className="h-full overflow-auto px-16 py-16 md:px-32 lg:px-48">
+        <div className="h-full overflow-auto px-16 py-16 md:px-24 lg:px-28 xl:px-44">
           <Outlet />
         </div>
       </main>

--- a/packages/frontend/src/components/layouts/search/Search.tsx
+++ b/packages/frontend/src/components/layouts/search/Search.tsx
@@ -28,6 +28,7 @@ export const Search = ({ className }: SearchProps) => {
         <Input
           placeholder="검색어"
           onChange={(e) => setStockName(e.target.value)}
+          autoFocus
         />
         <Button type="submit" size="sm">
           검색

--- a/packages/frontend/src/pages/login/Login.tsx
+++ b/packages/frontend/src/pages/login/Login.tsx
@@ -35,7 +35,7 @@ export const Login = () => {
 
 export const LoginButton = ({ to, src, alt, onClick }: LoginButtonProps) => {
   return (
-    <Link to={to} className="w-72" onClick={onClick}>
+    <Link to={to} className="w-72" onClick={onClick} reloadDocument>
       <img src={src} alt={alt} />
     </Link>
   );

--- a/packages/frontend/src/pages/my-page/MyPage.tsx
+++ b/packages/frontend/src/pages/my-page/MyPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { AlarmInfo } from './AlarmInfo';
 import { StockInfo } from './StockInfo';
+import { UserInfo } from './UserInfo';
 import { useGetLoginStatus } from '@/apis/queries/auth';
 
 export const MyPage = () => {
@@ -13,9 +14,9 @@ export const MyPage = () => {
       <h1 className="display-bold24 mb-16">마이페이지</h1>
       <article className="grid h-[40rem] grid-cols-[1.5fr_2.5fr] gap-5">
         <section className="grid grid-rows-[1fr_2fr] gap-5">
-          <section className="display-bold20 rounded-md bg-white p-7">
+          <section className="rounded-md bg-white p-7">
             {loginStatus?.message === 'Authenticated' ? (
-              '내정보'
+              <UserInfo />
             ) : (
               <Link
                 to="/login"

--- a/packages/frontend/src/pages/my-page/StockInfo.tsx
+++ b/packages/frontend/src/pages/my-page/StockInfo.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { GetLoginStatus } from '@/apis/queries/auth/schema';
 import { useGetUserStock } from '@/apis/queries/auth/useGetUserStock';
 import { useDeleteStockUser } from '@/apis/queries/stock-detail';
@@ -10,6 +11,7 @@ interface StockInfoProps {
 
 export const StockInfo = ({ loginStatus }: StockInfoProps) => {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { data } = useGetUserStock();
   const { mutate } = useDeleteStockUser({
@@ -29,7 +31,10 @@ export const StockInfo = ({ loginStatus }: StockInfoProps) => {
         ) : (
           <article className="grid grid-cols-2 gap-5">
             {data?.userStocks.map((stock) => (
-              <section className="display-bold14 text-dark-gray flex justify-between rounded bg-[#FAFAFA] p-10">
+              <section
+                className="display-bold14 text-dark-gray flex cursor-pointer justify-between rounded bg-[#FAFAFA] p-10 transition-all duration-300 hover:scale-105"
+                onClick={() => navigate(`/stocks/${stock.stockId}`)}
+              >
                 <p>{stock.name}</p>
                 <Button
                   size="sm"

--- a/packages/frontend/src/pages/my-page/StockInfo.tsx
+++ b/packages/frontend/src/pages/my-page/StockInfo.tsx
@@ -1,15 +1,46 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { GetLoginStatus } from '@/apis/queries/auth/schema';
+import { useGetUserStock } from '@/apis/queries/auth/useGetUserStock';
+import { useDeleteStockUser } from '@/apis/queries/stock-detail';
+import { Button } from '@/components/ui/button';
 
 interface StockInfoProps {
   loginStatus: GetLoginStatus;
 }
 
 export const StockInfo = ({ loginStatus }: StockInfoProps) => {
+  const queryClient = useQueryClient();
+
+  const { data } = useGetUserStock();
+  const { mutate } = useDeleteStockUser({
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['userStock'] }),
+  });
+
+  const { userStocks } = data || {};
+
   return (
     <section className="display-bold20 flex flex-col gap-5 rounded-md bg-white p-7">
       <h2>주식 정보</h2>
       {loginStatus?.message === 'Authenticated' ? (
-        <></>
+        userStocks?.length === 0 ? (
+          <p className="display-medium14 text-dark-gray">
+            소유한 주식이 없습니다.
+          </p>
+        ) : (
+          <article className="grid grid-cols-2 gap-5">
+            {data?.userStocks.map((stock) => (
+              <section className="display-bold14 text-dark-gray flex justify-between rounded bg-[#FAFAFA] p-10">
+                <p>{stock.name}</p>
+                <Button
+                  size="sm"
+                  onClick={() => mutate({ stockId: stock.stockId })}
+                >
+                  삭제
+                </Button>
+              </section>
+            ))}
+          </article>
+        )
       ) : (
         <p className="display-medium14 text-dark-gray">
           로그인 후 이용 가능합니다.

--- a/packages/frontend/src/pages/my-page/UserInfo.tsx
+++ b/packages/frontend/src/pages/my-page/UserInfo.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useGetUserInfo } from '@/apis/queries/auth/useGetUserInfo';
+import { usePostUserNickname } from '@/apis/queries/auth/usePostUserNickname';
+import { Input } from '@/components/ui/input';
+
+export const UserInfo = () => {
+  const [isEdit, setIsEdit] = useState(false);
+  const [newNickname, setNewNickname] = useState('');
+
+  const { data } = useGetUserInfo();
+  const { email, nickname } = data || {};
+
+  const { mutate } = usePostUserNickname({ nickname: newNickname });
+
+  return (
+    <div>
+      <div className="display-medium14 text-gray mb-5 flex gap-3">
+        <h2 className="display-bold20 text-black">내정보</h2>
+        {isEdit ? (
+          <>
+            <button
+              onClick={() => {
+                mutate();
+                setIsEdit(false);
+              }}
+            >
+              완료
+            </button>
+            <button onClick={() => setIsEdit(false)}>취소</button>
+          </>
+        ) : (
+          <button onClick={() => setIsEdit(true)}>수정</button>
+        )}
+      </div>
+      <section className="flex flex-col gap-3 [&>div]:flex [&>div]:gap-4">
+        <div>
+          <span className="text-gray">이메일</span>
+          <span className="text-dark-gray">{email}</span>
+        </div>
+        <div>
+          <span className="text-gray">닉네임</span>
+          {isEdit ? (
+            <Input
+              defaultValue={nickname}
+              autoFocus
+              onChange={(e) => setNewNickname(e.target.value)}
+            />
+          ) : (
+            <span className="text-dark-gray">{nickname}</span>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/packages/frontend/src/pages/my-page/UserInfo.tsx
+++ b/packages/frontend/src/pages/my-page/UserInfo.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useGetUserInfo } from '@/apis/queries/auth/useGetUserInfo';
+import { usePostLogout } from '@/apis/queries/auth/usePostLogout';
 import { usePostUserNickname } from '@/apis/queries/auth/usePostUserNickname';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 export const UserInfo = () => {
@@ -10,28 +12,41 @@ export const UserInfo = () => {
   const { data } = useGetUserInfo();
   const { email, nickname } = data || {};
 
-  const { mutate } = usePostUserNickname({ nickname: newNickname });
+  const { mutate: editNickname } = usePostUserNickname({
+    nickname: newNickname,
+  });
+  const { mutate: logout } = usePostLogout();
 
   return (
-    <div>
-      <div className="display-medium14 text-gray mb-5 flex gap-3">
-        <h2 className="display-bold20 text-black">내정보</h2>
-        {isEdit ? (
-          <>
-            <button
-              onClick={() => {
-                mutate();
-                setIsEdit(false);
-              }}
-            >
-              완료
-            </button>
-            <button onClick={() => setIsEdit(false)}>취소</button>
-          </>
-        ) : (
-          <button onClick={() => setIsEdit(true)}>수정</button>
-        )}
-      </div>
+    <div className="flex flex-col gap-5">
+      <section className="flex justify-between">
+        <div className="display-medium14 text-gray flex gap-3">
+          <h2 className="display-bold20 text-black">내정보</h2>
+          {isEdit ? (
+            <>
+              <button
+                onClick={() => {
+                  editNickname();
+                  setIsEdit(false);
+                }}
+              >
+                완료
+              </button>
+              <button onClick={() => setIsEdit(false)}>취소</button>
+            </>
+          ) : (
+            <button onClick={() => setIsEdit(true)}>수정</button>
+          )}
+        </div>
+        <Button
+          onClick={() => {
+            logout();
+            location.reload();
+          }}
+        >
+          로그아웃
+        </Button>
+      </section>
       <section className="flex flex-col gap-3 [&>div]:flex [&>div]:gap-4">
         <div>
           <span className="text-gray">이메일</span>

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -133,10 +133,9 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
             </span>
           </div>
         )}
-
         <section
           className={cn(
-            'flex h-[40rem] flex-col gap-8 overflow-auto p-3',
+            'flex h-[40rem] flex-col gap-8 overflow-auto break-words break-all p-3',
             isOwnerStock ? 'overflow-auto' : 'overflow-hidden',
           )}
         >

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -55,12 +55,12 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
       const validatedSingleChat = ChatDataSchema.partial().parse(message);
       if (validatedSingleChat) {
         setChatData((prev) => [
-          { nickname, ...validatedSingleChat } as ChatData,
+          { ...validatedSingleChat } as ChatData,
           ...prev,
         ]);
       }
     },
-    [nickname],
+    [],
   );
 
   const handleSendMessage = (message: string) => {

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -64,6 +64,8 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
   );
 
   const handleSendMessage = (message: string) => {
+    if (!message) return;
+
     socket.emit('chat', {
       room: stockId,
       content: message,

--- a/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
@@ -27,6 +27,7 @@ export const TextArea = ({ disabled, onSend, placeholder }: TextAreaProps) => {
           value={chatText}
           placeholder={placeholder}
           disabled={disabled}
+          autoFocus
           className={cn(
             'display-medium12 border-light-yellow h-20 w-full resize-none rounded-md border-4 p-3 pr-10 focus:outline-none',
             disabled && 'bg-light-gray/40 cursor-not-allowed',

--- a/packages/frontend/src/pages/stocks/StockRankingTable.tsx
+++ b/packages/frontend/src/pages/stocks/StockRankingTable.tsx
@@ -5,7 +5,7 @@ import { useGetStocksByPrice } from '@/apis/queries/stocks';
 import DownArrow from '@/assets/down-arrow.svg?react';
 import { cn } from '@/utils/cn';
 
-const LIMIT = 20;
+const LIMIT = 10;
 
 export const StockRankingTable = () => {
   const [sortType, setSortType] = useState<'increase' | 'decrease'>('increase');
@@ -49,35 +49,41 @@ export const StockRankingTable = () => {
           </tr>
         </thead>
         <tbody>
-          {data?.result.map((stock, index) => (
-            <tr
-              key={stock.id}
-              className="display-medium14 text-dark-gray text-right [&>*]:p-4"
-            >
-              <td className="flex gap-6 text-left">
-                <span className="text-gray w-3 flex-shrink-0">{index + 1}</span>
-                <Link
-                  to={`/stocks/${stock.id}`}
-                  onClick={() => mutate({ stockId: stock.id })}
-                  className="display-bold14 hover:text-orange cursor-pointer text-ellipsis hover:underline"
-                  aria-label={stock.name}
-                >
-                  {stock.name}
-                </Link>
-              </td>
-              <td>{stock.currentPrice?.toLocaleString()}원</td>
-              <td
-                className={cn(
-                  +stock.changeRate >= 0 ? 'text-red' : 'text-blue',
-                )}
+          {data ? (
+            data.result.map((stock, index) => (
+              <tr
+                key={stock.id}
+                className="display-medium14 text-dark-gray text-right [&>*]:p-4"
               >
-                {stock.changeRate >= 0 && '+'}
-                {stock.changeRate}%
-              </td>
-              <td>{stock.volume?.toLocaleString()}원</td>
-              <td>{stock.marketCap?.toLocaleString()}주</td>
-            </tr>
-          ))}
+                <td className="flex gap-6 text-left">
+                  <span className="text-gray w-3 flex-shrink-0">
+                    {index + 1}
+                  </span>
+                  <Link
+                    to={`/stocks/${stock.id}`}
+                    onClick={() => mutate({ stockId: stock.id })}
+                    className="display-bold14 hover:text-orange cursor-pointer text-ellipsis hover:underline"
+                    aria-label={stock.name}
+                  >
+                    {stock.name}
+                  </Link>
+                </td>
+                <td>{stock.currentPrice?.toLocaleString()}원</td>
+                <td
+                  className={cn(
+                    +stock.changeRate >= 0 ? 'text-red' : 'text-blue',
+                  )}
+                >
+                  {stock.changeRate >= 0 && '+'}
+                  {stock.changeRate}%
+                </td>
+                <td>{stock.volume?.toLocaleString()}원</td>
+                <td>{stock.marketCap?.toLocaleString()}주</td>
+              </tr>
+            ))
+          ) : (
+            <p className="py-3">종목 정보를 불러오는데 실패했어요.</p>
+          )}
         </tbody>
       </table>
     </div>

--- a/packages/frontend/src/pages/stocks/Stocks.tsx
+++ b/packages/frontend/src/pages/stocks/Stocks.tsx
@@ -54,7 +54,7 @@ export const Stocks = () => {
                 changeRate={stock.changeRate || 0}
                 onClick={() => {
                   mutate({ stockId: stock.id ?? '' });
-                  navigate(`stocks/${stock.id}`);
+                  navigate(`/stocks/${stock.id}`);
                 }}
               />
             ))

--- a/packages/frontend/src/pages/stocks/Stocks.tsx
+++ b/packages/frontend/src/pages/stocks/Stocks.tsx
@@ -4,18 +4,14 @@ import { StockInfoCard } from './components/StockInfoCard';
 import { StockRankingTable } from './StockRankingTable';
 import { usePostStockView } from '@/apis/queries/stock-detail';
 import { useGetTopViews } from '@/apis/queries/stocks';
-import marketData from '@/mocks/market.json';
+import { useGetStockIndex } from '@/apis/queries/stocks/useGetStockIndex';
 
 const LIMIT = 5;
 
 export const Stocks = () => {
   const navigate = useNavigate();
-  const kospi = marketData.data.filter((value) => value.name === '코스피')[0];
-  const kosdaq = marketData.data.filter((value) => value.name === '코스닥')[0];
-  const rateOfExchange = marketData.data.filter(
-    (value) => value.name === '달러환율',
-  )[0];
 
+  const { data: stockIndex } = useGetStockIndex();
   const { data: topViews } = useGetTopViews({ limit: LIMIT });
   const { mutate } = usePostStockView();
 
@@ -26,29 +22,23 @@ export const Stocks = () => {
         <h2 className="display-bold16 text-dark-gray mb-5">
           지금 시장, 이렇게 움직이고 있어요.
         </h2>
-        <div className="grid w-fit grid-cols-3 gap-5">
-          <StockIndexCard
-            price={kospi.price}
-            change={kospi.change}
-            changePercent={kospi.changePercent}
-          >
-            코스피
-          </StockIndexCard>
-          <StockIndexCard
-            price={kosdaq.price}
-            change={kosdaq.change}
-            changePercent={kosdaq.changePercent}
-          >
-            코스닥
-          </StockIndexCard>
-          <StockIndexCard
-            price={rateOfExchange.price}
-            change={rateOfExchange.change}
-            changePercent={rateOfExchange.changePercent}
-          >
-            달러환율
-          </StockIndexCard>
-        </div>
+        {stockIndex ? (
+          <div className="grid w-fit grid-cols-3 gap-5">
+            {stockIndex?.map((info) => (
+              <StockIndexCard
+                name={info.name}
+                currentPrice={info.currentPrice}
+                changeRate={info.changeRate}
+                volume={info.volume}
+                high={info.high}
+                low={info.low}
+                open={info.open}
+              />
+            ))}
+          </div>
+        ) : (
+          <p>지수 정보를 불러오는 데 실패했습니다.</p>
+        )}
       </article>
       <article>
         <h2 className="display-bold16 text-dark-gray mb-5">

--- a/packages/frontend/src/pages/stocks/Stocks.tsx
+++ b/packages/frontend/src/pages/stocks/Stocks.tsx
@@ -36,7 +36,7 @@ export const Stocks = () => {
             ))}
           </div>
         ) : (
-          <p>지수 정보를 불러오는 데 실패했습니다.</p>
+          <p>지수 정보를 불러오는 데 실패했어요.</p>
         )}
       </article>
       <article>
@@ -44,19 +44,23 @@ export const Stocks = () => {
           이 종목은 어떠신가요?
         </h2>
         <div className="grid w-fit grid-cols-5 gap-5">
-          {topViews?.map((stock, index) => (
-            <StockInfoCard
-              key={stock.id}
-              index={index}
-              name={stock.name}
-              currentPrice={stock.currentPrice}
-              changeRate={stock.changeRate}
-              onClick={() => {
-                mutate({ stockId: stock.id });
-                navigate(stock.id);
-              }}
-            />
-          ))}
+          {topViews ? (
+            topViews.map((stock, index) => (
+              <StockInfoCard
+                key={stock.id}
+                index={index}
+                name={stock.name || ''}
+                currentPrice={stock.currentPrice || 0}
+                changeRate={stock.changeRate || 0}
+                onClick={() => {
+                  mutate({ stockId: stock.id ?? '' });
+                  navigate(`stocks/${stock.id}`);
+                }}
+              />
+            ))
+          ) : (
+            <p>종목 정보를 불러오는데 실패했어요.</p>
+          )}
         </div>
       </article>
       <article>

--- a/packages/frontend/src/pages/stocks/Stocks.tsx
+++ b/packages/frontend/src/pages/stocks/Stocks.tsx
@@ -29,7 +29,6 @@ export const Stocks = () => {
                 name={info.name}
                 currentPrice={info.currentPrice}
                 changeRate={info.changeRate}
-                volume={info.volume}
                 high={info.high}
                 low={info.low}
                 open={info.open}

--- a/packages/frontend/src/pages/stocks/components/StockIndexCard.tsx
+++ b/packages/frontend/src/pages/stocks/components/StockIndexCard.tsx
@@ -5,7 +5,6 @@ export const StockIndexCard = ({
   name,
   currentPrice,
   changeRate,
-  volume,
   high,
   low,
   open,
@@ -28,10 +27,6 @@ export const StockIndexCard = ({
         <div>
           <span className="display-bold14">시가</span>
           <span className="display-medium14">{open?.toLocaleString()}</span>
-        </div>
-        <div>
-          <span className="display-bold14">거래량</span>
-          <span className="display-medium14">{volume?.toLocaleString()}</span>
         </div>
         <div>
           <span className="display-bold14">고가</span>

--- a/packages/frontend/src/pages/stocks/components/StockIndexCard.tsx
+++ b/packages/frontend/src/pages/stocks/components/StockIndexCard.tsx
@@ -1,32 +1,47 @@
-import { type ReactNode } from 'react';
+import { StockIndexResponse } from '@/apis/queries/stocks';
 import { cn } from '@/utils/cn';
 
-interface StockIndexCardProps {
-  children: ReactNode;
-  price: number;
-  change: number;
-  changePercent: number;
-}
-
 export const StockIndexCard = ({
-  children,
-  price,
-  change,
-  changePercent,
-}: StockIndexCardProps) => {
+  name,
+  currentPrice,
+  changeRate,
+  volume,
+  high,
+  low,
+  open,
+}: Partial<StockIndexResponse>) => {
   return (
-    <div className="flex w-full cursor-pointer flex-col gap-2 rounded-md bg-white py-4 pl-5 pr-28 shadow transition-all duration-300 hover:scale-110">
-      <p className="display-medium16">{children}</p>
-      <p className="display-bold24 text-dark-gray">{price}</p>
-      <p
-        className={cn(
-          'display-medium14',
-          changePercent >= 0 ? 'text-red' : 'text-blue',
-        )}
-      >
-        {changePercent >= 0 ? '▲' : '▼'}
-        {change}({changePercent})
-      </p>
+    <div className="flex w-full cursor-pointer flex-col gap-2 rounded-md bg-white py-4 pl-5 pr-20 shadow transition-all duration-300 hover:scale-105">
+      <p className="display-bold16 text-dark-gray">{name}</p>
+      <div className="flex items-center gap-3">
+        <span className="display-bold24 text-dark-gray">{currentPrice}</span>
+        <span
+          className={cn(
+            'display-medium14',
+            changeRate && +changeRate >= 0 ? 'text-red' : 'text-blue',
+          )}
+        >
+          {changeRate}%
+        </span>
+      </div>
+      <div className="text-gray grid grid-cols-2 grid-rows-2 gap-3 [&_div]:flex [&_div]:gap-4">
+        <div>
+          <span className="display-bold14">시가</span>
+          <span className="display-medium14">{open?.toLocaleString()}</span>
+        </div>
+        <div>
+          <span className="display-bold14">거래량</span>
+          <span className="display-medium14">{volume?.toLocaleString()}</span>
+        </div>
+        <div>
+          <span className="display-bold14">고가</span>
+          <span className="display-medium14">{high?.toLocaleString()}</span>
+        </div>
+        <div>
+          <span className="display-bold14">저가</span>
+          <span className="display-medium14">{low?.toLocaleString()}</span>
+        </div>
+      </div>
     </div>
   );
 };

--- a/packages/frontend/src/pages/stocks/components/StockIndexCard.tsx
+++ b/packages/frontend/src/pages/stocks/components/StockIndexCard.tsx
@@ -13,7 +13,7 @@ export const StockIndexCard = ({
     <div className="flex w-full cursor-pointer flex-col gap-2 rounded-md bg-white py-4 pl-5 pr-20 shadow transition-all duration-300 hover:scale-105">
       <p className="display-bold16 text-dark-gray">{name}</p>
       <div className="flex items-center gap-3">
-        <span className="display-bold24 text-dark-gray">{currentPrice}</span>
+        <span className="display-bold20 text-dark-gray">{currentPrice}</span>
         <span
           className={cn(
             'display-medium14',

--- a/packages/frontend/src/pages/stocks/components/StockInfoCard.tsx
+++ b/packages/frontend/src/pages/stocks/components/StockInfoCard.tsx
@@ -1,9 +1,7 @@
+import { type GetStockTopViewsResponse } from '@/apis/queries/stocks';
 import { cn } from '@/utils/cn';
 
-interface StockInfoCardProps {
-  name: string;
-  currentPrice: number;
-  changeRate: number;
+interface StockInfoCardProps extends GetStockTopViewsResponse {
   index: number;
   onClick: () => void;
 }
@@ -14,34 +12,35 @@ export const StockInfoCard = ({
   changeRate,
   index,
   onClick,
-}: StockInfoCardProps) => {
+}: Partial<StockInfoCardProps>) => {
   return (
     <div
       className={cn(
-        'flex cursor-pointer flex-col gap-2 rounded-md py-4 pl-5 pr-12 shadow transition-all duration-300 hover:scale-105',
+        'flex cursor-pointer flex-col gap-2 rounded-md p-2 shadow transition-all duration-300 hover:scale-105 lg:py-4 lg:pl-5 lg:pr-12',
         index === 0 ? 'bg-light-yellow' : 'bg-white',
       )}
       onClick={onClick}
     >
-      <p className="display-bold16 text-dark-gray mb-3 text-ellipsis">{name}</p>
-      <div className="flex items-center gap-5">
-        <span className="display-bold12 text-dark-gray">등락률</span>
-        <span
-          className={cn(
-            'display-bold16',
-            changeRate >= 0 ? 'text-red' : 'text-blue',
-          )}
-        >
-          {changeRate >= 0 && '+'}
-          {changeRate}%
-        </span>
-      </div>
-      <div className="flex items-center gap-5">
-        <span className="display-bold12 text-dark-gray">현재가</span>
-        <span className="display-medium12 text-dark-gray">
-          {currentPrice?.toLocaleString()}
-        </span>
-      </div>
+      <p className="display-bold16 text-dark-gray mb-3">{name}</p>
+      <section className="flex flex-row gap-3 xl:flex-col">
+        <div className="flex flex-col items-start gap-2 xl:flex-row xl:items-center xl:gap-5">
+          <span className="display-bold12 text-dark-gray">등락률</span>
+          <span
+            className={cn(
+              'xl:display-bold16 display-bold12',
+              changeRate && changeRate >= 0 ? 'text-red' : 'text-blue',
+            )}
+          >
+            {changeRate}%
+          </span>
+        </div>
+        <div className="flex flex-col items-start gap-2 xl:flex-row xl:items-center xl:gap-5">
+          <span className="display-bold12 text-dark-gray">현재가</span>
+          <span className="display-medium12 text-dark-gray">
+            {currentPrice?.toLocaleString()}
+          </span>
+        </div>
+      </section>
     </div>
   );
 };

--- a/packages/frontend/src/pages/stocks/components/StockInfoCard.tsx
+++ b/packages/frontend/src/pages/stocks/components/StockInfoCard.tsx
@@ -16,13 +16,13 @@ export const StockInfoCard = ({
   return (
     <div
       className={cn(
-        'flex cursor-pointer flex-col gap-2 rounded-md p-2 shadow transition-all duration-300 hover:scale-105 lg:py-4 lg:pl-5 lg:pr-12',
+        'flex cursor-pointer flex-col gap-2 rounded-md p-2 shadow transition-all duration-300 hover:scale-105 lg:py-4 lg:pl-5 lg:pr-16',
         index === 0 ? 'bg-light-yellow' : 'bg-white',
       )}
       onClick={onClick}
     >
       <p className="display-bold16 text-dark-gray mb-3">{name}</p>
-      <section className="flex flex-row gap-3 xl:flex-col">
+      <section className="flex flex-row gap-2 xl:flex-col">
         <div className="flex flex-col items-start gap-2 xl:flex-row xl:items-center xl:gap-5">
           <span className="display-bold12 text-dark-gray">등락률</span>
           <span


### PR DESCRIPTION
close #182 

## ✅ 작업 내용

- 메인페이지
  - 지수 정보 불러오기
  - 조회수 순 수정
- 마이페이지
  - 유저 정보 불러오기(이메일, 닉네임)
  - 닉네임 수정
  - 주식 소유 정보 불러오기
  - 주식 소유 정보 삭제 기능
- 채팅 emit시 모두에게 자신의 닉네임으로 브로드캐스팅 되는 문제 해결

## 📸 스크린샷(FE만)

![image](https://github.com/user-attachments/assets/4b7db20a-d3b1-48e6-96b4-98f84b06f94a)
![image](https://github.com/user-attachments/assets/d48deda0-d5cb-4a1a-9f06-8ba75f84b644)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
