### PR TITLE
Feature/#297 - 가격 등락률 순 api 추가

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,6 +36,7 @@
     "@storybook/react": "8.4.3",
     "@storybook/react-vite": "8.4.3",
     "@storybook/test": "8.4.3",
+    "@tanstack/react-query-devtools": "^5.62.0",
     "@types/node": "^22.8.7",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './routes';
 
@@ -8,7 +9,7 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-      {/* TODO:react query devtools 설치 */}
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
 };

--- a/packages/frontend/src/apis/queries/stocks/schema.ts
+++ b/packages/frontend/src/apis/queries/stocks/schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 
 export const GetStockListRequestSchema = z.object({
-  limit: z.number(),
+  limit: z.number().optional(),
+  type: z.enum(['all', 'increase', 'decrease']).optional(),
 });
 
 export type GetStockListRequest = z.infer<typeof GetStockListRequestSchema>;

--- a/packages/frontend/src/apis/queries/stocks/useGetStockIndex.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetStockIndex.ts
@@ -13,6 +13,5 @@ export const useGetStockIndex = () => {
   return useQuery({
     queryKey: ['stockIndex'],
     queryFn: getStockIndex,
-    staleTime: 1000 * 60,
   });
 };

--- a/packages/frontend/src/apis/queries/stocks/useGetStockIndex.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetStockIndex.ts
@@ -13,5 +13,6 @@ export const useGetStockIndex = () => {
   return useQuery({
     queryKey: ['stockIndex'],
     queryFn: getStockIndex,
+    staleTime: 1000 * 60,
   });
 };

--- a/packages/frontend/src/apis/queries/stocks/useGetStocksByPrice.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetStocksByPrice.ts
@@ -17,6 +17,5 @@ export const useGetStocksByPrice = ({ limit, type }: GetStockListRequest) => {
   return useQuery({
     queryKey: ['stocks', limit, type],
     queryFn: () => getStockByPrice({ limit, type }),
-    staleTime: 1000 * 60,
   });
 };

--- a/packages/frontend/src/apis/queries/stocks/useGetStocksByPrice.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetStocksByPrice.ts
@@ -6,16 +6,17 @@ import {
 } from './schema';
 import { get } from '@/apis/utils/get';
 
-const getStockByPrice = ({ limit }: Partial<GetStockListRequest>) =>
+const getStockByPrice = ({ limit, type }: GetStockListRequest) =>
   get<GetStockListResponse>({
     schema: GetStockListResponseSchema,
     url: `/api/stock/fluctuation`,
-    params: { limit },
+    params: { limit, type },
   });
 
-export const useGetStocksByPrice = ({ limit }: GetStockListRequest) => {
+export const useGetStocksByPrice = ({ limit, type }: GetStockListRequest) => {
   return useQuery({
-    queryKey: ['stocks', limit],
-    queryFn: () => getStockByPrice({ limit }),
+    queryKey: ['stocks', limit, type],
+    queryFn: () => getStockByPrice({ limit, type }),
+    staleTime: 1000 * 60,
   });
 };

--- a/packages/frontend/src/pages/stocks/StockRankingTable.tsx
+++ b/packages/frontend/src/pages/stocks/StockRankingTable.tsx
@@ -10,7 +10,7 @@ const LIMIT = 10;
 export const StockRankingTable = () => {
   const [sortType, setSortType] = useState<'increase' | 'decrease'>('increase');
 
-  const { data } = useGetStocksByPrice({ limit: LIMIT });
+  const { data } = useGetStocksByPrice({ limit: LIMIT, type: sortType });
   const { mutate } = usePostStockView();
 
   const handleSortType = () => {
@@ -74,7 +74,6 @@ export const StockRankingTable = () => {
                     +stock.changeRate >= 0 ? 'text-red' : 'text-blue',
                   )}
                 >
-                  {stock.changeRate >= 0 && '+'}
                   {stock.changeRate}%
                 </td>
                 <td>{stock.volume?.toLocaleString()}원</td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,6 +1864,18 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.59.17.tgz#bda3bb678be48e2f6ee692abd1cfc2db3d455e4b"
   integrity sha512-jWdDiif8kaqnRGHNXAa9CnudtxY5v9DUxXhodgqX2Rwzj+1UwStDHEbBd9IA5C7VYAaJ2s+BxFR6PUBs8ERorA==
 
+"@tanstack/query-devtools@5.61.4":
+  version "5.61.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.61.4.tgz#86a3be0ffb97d810525600e3787b5b69808cf9db"
+  integrity sha512-21Tw+u8E3IJJj4A/Bct4H0uBaDTEu7zBrR79FeSyY+mS2gx5/m316oDtJiKkILc819VSTYt+sFzODoJNcpPqZQ==
+
+"@tanstack/react-query-devtools@^5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.62.0.tgz#f823cea362fbc3d2dc3a40de1c075bea35e89f1b"
+  integrity sha512-9NWUgpfRPiUpsPdYopddbQLjWXbMBNaxM7K5VXPZIPfcfJJ4mG6VqrEJysL/79zgl7hC9kJlP+zXA0r5niomdg==
+  dependencies:
+    "@tanstack/query-devtools" "5.61.4"
+
 "@tanstack/react-query@^5.59.19":
   version "5.59.19"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.59.19.tgz#309ae0d75844e331ea72762bfe0e11fb829a69d3"
@@ -6190,11 +6202,6 @@ jsdoc-type-pratt-parser@^4.0.0:
   resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz#ff6b4a3f339c34a6c188cbf50a16087858d22113"
   integrity sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==
 
-jsdoc-type-pratt-parser@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz#ff6b4a3f339c34a6c188cbf50a16087858d22113"
-  integrity sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==
-
 jsesc@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
@@ -7169,7 +7176,6 @@ pathval@^2.0.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
   integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
 
-
 pause@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
@@ -7538,7 +7544,6 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
-
 
 reflect-metadata@^0.2.0, reflect-metadata@^0.2.1:
   version "0.2.2"
@@ -7927,13 +7932,6 @@ socket.io-client@^4.8.1:
     debug "~4.3.2"
     engine.io-client "~6.6.1"
     socket.io-parser "~4.2.4"
-socket.io-adapter@~2.5.2:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz#c7a1f9c703d7756844751b6ff9abfc1780664082"
-  integrity sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==
-  dependencies:
-    debug "~4.3.4"
-    ws "~8.17.1"
 
 socket.io-parser@~4.2.4:
   version "4.2.4"
@@ -7968,7 +7966,7 @@ socket.io@^4.8.1:
     engine.io "~6.6.0"
     socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.4"
-    
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -8552,7 +8550,6 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-
 tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.5.0, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
@@ -9066,7 +9063,6 @@ ws@~8.17.1:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
-
 
 xmlhttprequest-ssl@~2.1.1:
   version "2.1.2"


### PR DESCRIPTION
close #297 

## ✅ 작업 내용

- 변경된 명세에 따라 등락률 순 api 요청 시 type을 보내도록 했습니다.
- 상승/하락순 정렬을 확인하실 수 있습니다.

## 📸 스크린샷(FE만)

https://github.com/user-attachments/assets/5e646b36-8959-4b79-ab6f-f76a2f5d7fc9


## ✍ 궁금한 점

지수 정보/등락률 순 데이터를 서버에서 받아올 때 갱신되는 주기가 궁금합니다.

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
