### PR TITLE
Feature/#266 - 주식 정보에 단위 추가

### DIFF
--- a/packages/frontend/src/components/ui/input/Input.tsx
+++ b/packages/frontend/src/components/ui/input/Input.tsx
@@ -5,7 +5,12 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   className?: string;
 }
 
-export const Input = ({ placeholder, className, ...props }: InputProps) => {
+export const Input = ({
+  placeholder,
+  className,
+  onChange,
+  ...props
+}: InputProps) => {
   return (
     <input
       placeholder={placeholder}
@@ -13,6 +18,7 @@ export const Input = ({ placeholder, className, ...props }: InputProps) => {
         'border-dark-gray w-36 border-b bg-white focus:outline-none',
         className,
       )}
+      onChange={onChange}
       {...props}
     />
   );

--- a/packages/frontend/src/constants/metricDetail.ts
+++ b/packages/frontend/src/constants/metricDetail.ts
@@ -52,19 +52,19 @@ export const METRICS_DATA = ({
       metrics: [
         {
           ...METRIC_DETAILS.price.currentPrice,
-          value: price?.toLocaleString(),
+          value: `${price?.toLocaleString()}원`,
         },
         {
           ...METRIC_DETAILS.price.tradingVolume,
-          value: volume?.toLocaleString(),
+          value: `${volume?.toLocaleString()}주`,
         },
         {
           ...METRIC_DETAILS.price.fluctuationRate,
-          value: change?.toLocaleString(),
+          value: `${change?.toLocaleString()}%`,
         },
         {
           ...METRIC_DETAILS.price.fiftyTwoWeekRange,
-          value: `${high52w?.toLocaleString()}/${low52w?.toLocaleString()}`,
+          value: `${high52w?.toLocaleString()}원/${low52w?.toLocaleString()}원`,
         },
       ],
     },
@@ -74,7 +74,7 @@ export const METRICS_DATA = ({
       metrics: [
         {
           ...METRIC_DETAILS.enterpriseValue.marketCap,
-          value: marketCap?.toLocaleString(),
+          value: `${marketCap?.toLocaleString()}원`,
         },
         {
           ...METRIC_DETAILS.enterpriseValue.per,
@@ -82,7 +82,7 @@ export const METRICS_DATA = ({
         },
         {
           ...METRIC_DETAILS.enterpriseValue.eps,
-          value: eps?.toLocaleString(),
+          value: `${eps?.toLocaleString()}원`,
         },
       ],
     },

--- a/packages/frontend/src/pages/stock-detail/AddAlarmForm.tsx
+++ b/packages/frontend/src/pages/stock-detail/AddAlarmForm.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ALARM_OPTIONS } from '@/constants/alarmOptions';
@@ -7,7 +8,10 @@ interface AddAlarmFormProps {
   className?: string;
 }
 
+type AlarmMethod = 'push' | 'email';
+
 export const AddAlarmForm = ({ className }: AddAlarmFormProps) => {
+  const [alarmMethod, setAlarmMethod] = useState<AlarmMethod>('push');
   const handleSubmit = () => {};
 
   return (
@@ -49,11 +53,18 @@ export const AddAlarmForm = ({ className }: AddAlarmFormProps) => {
                 id="push"
                 checked
                 className="w-fit"
+                onChange={() => setAlarmMethod('push')}
               />
               <label htmlFor="push" className="display-medium14">
                 웹 푸시
               </label>
-              <Input type="radio" name="method" id="email" className="w-fit" />
+              <Input
+                type="radio"
+                name="method"
+                id="email"
+                className="w-fit"
+                onChange={() => setAlarmMethod('email')}
+              />
               <label htmlFor="email" className="display-medium14">
                 이메일
               </label>

--- a/packages/frontend/src/pages/stocks/components/StockIndexCard.tsx
+++ b/packages/frontend/src/pages/stocks/components/StockIndexCard.tsx
@@ -26,15 +26,15 @@ export const StockIndexCard = ({
       <div className="text-gray grid grid-cols-2 grid-rows-2 gap-3 [&_div]:flex [&_div]:gap-4">
         <div>
           <span className="display-bold14">시가</span>
-          <span className="display-medium14">{open?.toLocaleString()}</span>
+          <span className="display-medium14">{open?.toLocaleString()}원</span>
         </div>
         <div>
           <span className="display-bold14">고가</span>
-          <span className="display-medium14">{high?.toLocaleString()}</span>
+          <span className="display-medium14">{high?.toLocaleString()}원</span>
         </div>
         <div>
           <span className="display-bold14">저가</span>
-          <span className="display-medium14">{low?.toLocaleString()}</span>
+          <span className="display-medium14">{low?.toLocaleString()}원</span>
         </div>
       </div>
     </div>

--- a/packages/frontend/src/pages/stocks/components/StockInfoCard.tsx
+++ b/packages/frontend/src/pages/stocks/components/StockInfoCard.tsx
@@ -37,7 +37,7 @@ export const StockInfoCard = ({
         <div className="flex flex-col items-start gap-2 xl:flex-row xl:items-center xl:gap-5">
           <span className="display-bold12 text-dark-gray">현재가</span>
           <span className="display-medium12 text-dark-gray">
-            {currentPrice?.toLocaleString()}
+            {currentPrice?.toLocaleString()}원
           </span>
         </div>
       </section>


### PR DESCRIPTION
close #266 

## ✅ 작업 내용

- 지수정보, 조회수순 정보, 상세 정보에 단위를 추가했습니다. 수정해야할 단위가 있다면 알려주세요
- live data는 웹소켓을 연결해둔 상태였어서 데이터가 들어오니 잘 보이네요!

## 📸 스크린샷(FE만)

![image](https://github.com/user-attachments/assets/674248ef-e8fc-4e0d-9f40-89bdef4f25cc)
![image](https://github.com/user-attachments/assets/6350bd08-44b5-48cc-b239-bad106f038a8)
![image](https://github.com/user-attachments/assets/75fca6f9-e679-454a-b989-aeee8170c88c)


## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
