### PR TITLE
Feature/#311 - 로컬 캐시 적용 및 채팅 엔드포인트 수정

### DIFF
--- a/packages/backend/src/chat/dto/chat.request.ts
+++ b/packages/backend/src/chat/dto/chat.request.ts
@@ -45,6 +45,17 @@ export function isChatScrollQuery(object: unknown): object is ChatScrollQuery {
   return !('pageSize' in object && !Number.isInteger(Number(object.pageSize)));
 }
 
+export class SortedChatScrollQuery extends ChatScrollQuery {
+  @ApiProperty({
+    description: '정렬 기준(기본은 최신 순)',
+    example: 'latest',
+    enum: ['latest', 'like'],
+    required: false,
+  })
+  @IsOptional()
+  order: string;
+}
+
 export interface ChatMessage {
   room: string;
   content: string;

--- a/packages/backend/src/common/cache/localCache.ts
+++ b/packages/backend/src/common/cache/localCache.ts
@@ -1,33 +1,64 @@
+import { PriorityQueue } from '@/scraper/openapi/util/priorityQueue';
+
 type CacheEntry<T> = {
   value: T;
-  expireAt: number;
+  expiredAt: number;
+};
+
+type CacheQueueEntry<T> = {
+  value: T;
+  expiredAt: number;
 };
 
 export class LocalCache<K, V> {
   private readonly localCache: Map<K, CacheEntry<V>> = new Map();
+  private readonly ttlQueue: PriorityQueue<CacheQueueEntry<K>> =
+    new PriorityQueue();
 
-  get(key: K): V | null {
+  constructor(private readonly interval = 500) {
+    setInterval(() => this.clearExpired(), interval);
+  }
+
+  get(key: K) {
     const entry = this.localCache.get(key);
     if (!entry) {
       return null;
     }
-    if (entry.expireAt < Date.now()) {
+    if (entry.expiredAt < Date.now()) {
       this.localCache.delete(key);
       return null;
     }
     return entry.value;
   }
 
-  set(key: K, value: V, ttl: number) {
-    const expireAt = Date.now() + ttl;
-    this.localCache.set(key, { value, expireAt });
+  async set(key: K, value: V, ttl: number) {
+    const expiredAt = Date.now() + ttl;
+    this.localCache.set(key, { value, expiredAt });
+    this.ttlQueue.enqueue({ value: key, expiredAt }, expiredAt);
   }
 
-  delete(key: K) {
+  async delete(key: K) {
     this.localCache.delete(key);
   }
 
   clear() {
     this.localCache.clear();
+  }
+
+  private clearExpired() {
+    const now = Date.now();
+    while (!this.ttlQueue.isEmpty()) {
+      const key = this.ttlQueue.dequeue()!;
+      if (key.expiredAt > now) {
+        this.ttlQueue.enqueue(key, key.expiredAt);
+        break;
+      }
+      if (
+        this.localCache.has(key.value) &&
+        this.localCache.get(key.value)!.expiredAt === key.expiredAt
+      ) {
+        this.localCache.delete(key.value);
+      }
+    }
   }
 }

--- a/packages/backend/src/common/cache/localCache.ts
+++ b/packages/backend/src/common/cache/localCache.ts
@@ -1,0 +1,33 @@
+type CacheEntry<T> = {
+  value: T;
+  expireAt: number;
+};
+
+export class LocalCache<K, V> {
+  private readonly localCache: Map<K, CacheEntry<V>> = new Map();
+
+  get(key: K): V | null {
+    const entry = this.localCache.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expireAt < Date.now()) {
+      this.localCache.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  set(key: K, value: V, ttl: number) {
+    const expireAt = Date.now() + ttl;
+    this.localCache.set(key, { value, expireAt });
+  }
+
+  delete(key: K) {
+    this.localCache.delete(key);
+  }
+
+  clear() {
+    this.localCache.clear();
+  }
+}

--- a/packages/backend/src/scraper/openapi/util/priorityQueue.ts
+++ b/packages/backend/src/scraper/openapi/util/priorityQueue.ts
@@ -34,6 +34,10 @@ export class PriorityQueue<T> {
     return this.heap.length === 0;
   }
 
+  clear() {
+    this.heap = [];
+  }
+
   private getParentIndex(index: number): number {
     return Math.floor((index - 1) / 2);
   }

--- a/packages/backend/src/stock/cache/stockData.cache.ts
+++ b/packages/backend/src/stock/cache/stockData.cache.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { LocalCache } from '@/common/cache/localCache';
+import { StockDataResponse } from '@/stock/dto/stockData.response';
+
+@Injectable()
+export class StockDataCache {
+  private readonly localCache = new LocalCache<string, StockDataResponse>();
+
+  set(key: string, value: StockDataResponse, ttl: number = 60000) {
+    this.localCache.set(key, value, ttl);
+  }
+
+  get(key: string): StockDataResponse | null {
+    return this.localCache.get(key);
+  }
+}

--- a/packages/backend/src/stock/stock.module.ts
+++ b/packages/backend/src/stock/stock.module.ts
@@ -27,6 +27,8 @@ import { StockRateIndexService } from './stockRateIndex.service';
 import { AlarmModule } from '@/alarm/alarm.module';
 import { Alarm } from '@/alarm/domain/alarm.entity';
 import { ScraperModule } from '@/scraper/scraper.module';
+import { StockDataCache } from '@/stock/cache/stockData.cache';
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -45,6 +47,7 @@ import { ScraperModule } from '@/scraper/scraper.module';
   ],
   controllers: [StockController],
   providers: [
+    StockDataCache,
     StockService,
     StockGateway,
     StockLiveDataSubscriber,

--- a/packages/backend/src/utils/date.ts
+++ b/packages/backend/src/utils/date.ts
@@ -1,0 +1,4 @@
+export function getFormattedDate(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1)
+    .padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}


### PR DESCRIPTION
close #311 

## ✅ 작업 내용
- 로컬 캐시 구현
- 그래프 스크롤에 캐시를 적용
- 채팅 스크롤 엔드포인트 변경 (최신순과 좋아요 순을 합침)

## 📌 이슈 사항
- 제가 만든 로컬 캐시의 특징은 다음과 같습니다.
  - 캐시 엔트리가 저장되는 자료구조는 Map입니다.
  - TTL 기능도 추가로 도입했습니다. 2가지 방법으로 진행됩니다.
    - 사용자가 특정 키를 조회했을 때 만료가 되면 삭제
    - 일정 시간의 간격으로 주기적으로 체크
      - 일단 이전에 구현한 우선순위 큐에 키와 만료 기간을 넣어서 삭제를 진행하고 있습니다. 만료 기간이 빠른 순으로 큐에 꺼내서 조회를 진행하고, 큐의 만료기간이 캐시의 만료 기간이 일치하면 삭제하도록 합니다. (중간에 같은 키 값으로 새로 갱신한 엔트리가 존재할 수 있기 때문입니다.)
      - 여유가 된다면 redis 방법을 사용하려고 합니다. redis의 방식은 만료 테이블에서 20개 row를 선택해서 만료가 25%인지 확인한 후 25%를 넘으면 계속 진행하는 방식으로 진행됩니다. 아마도 Map의 keys()를 통해 구현할 예정입니다.
- 캐시를 적용하긴 했지만, 로컬 상에는 그래프 데이터를 DB 상에서 조회 했을 때와 큰 차이가 없습니다. 하지만 테스트 해본 데이터는 7만 row만 존재하는 년 단위 데이터였습니다. 만약 700만 row수를 가진 일 단위 데이터였다면 효과가 있을 수 있고, 배포 상의 DB를 조회하는데 시간이 좀 걸리기 때문에 성능이 향상될 수 있습니다.
- 일단 제 예상에 500명 기준에서 무한 새로고침을 한다고 가정하면(네트워크 latency가 로컬과 같다면) 1.5초 ~ 2초 정도로 예상합니다!
## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
