### PR TITLE
Feature/#126 - 주식 그래프 무한스크롤 구현

### DIFF
--- a/packages/frontend/src/apis/queries/stocks/useGetStocksPriceSeries.ts
+++ b/packages/frontend/src/apis/queries/stocks/useGetStocksPriceSeries.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import {
   StockTimeSeriesResponseSchema,
   type StockTimeSeriesRequest,
@@ -25,8 +25,26 @@ export const useGetStocksPriceSeries = ({
   lastStartTime,
   timeunit,
 }: StockTimeSeriesRequest) => {
-  return useQuery({
-    queryKey: ['stocksTimeSeries', stockId, lastStartTime, timeunit],
-    queryFn: () => getStocksPriceSeries({ stockId, lastStartTime, timeunit }),
+  return useInfiniteQuery({
+    queryKey: ['stocksTimeSeries', stockId, timeunit],
+    queryFn: ({ pageParam }) =>
+      getStocksPriceSeries({
+        stockId,
+        lastStartTime: pageParam?.lastStartTime ?? lastStartTime,
+        timeunit,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore
+        ? {
+            lastStartTime: lastPage.priceDtoList[0].startTime,
+          }
+        : undefined,
+    initialPageParam: { lastStartTime },
+    select: (data) => ({
+      pages: [...data.pages].reverse(),
+      pageParams: [...data.pageParams].reverse(),
+    }),
+    refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/packages/frontend/src/apis/queries/user/useGetUserTheme.ts
+++ b/packages/frontend/src/apis/queries/user/useGetUserTheme.ts
@@ -13,5 +13,6 @@ export const useGetUserTheme = () => {
     queryKey: ['userTheme'],
     queryFn: getUserTheme,
     staleTime: 1000 * 60 * 5,
+    select: (data) => data.theme,
   });
 };

--- a/packages/frontend/src/components/layouts/Sidebar.tsx
+++ b/packages/frontend/src/components/layouts/Sidebar.tsx
@@ -22,16 +22,16 @@ export const Sidebar = () => {
     alarm: false,
   });
 
-  const { data } = useGetUserTheme();
+  const { data: theme } = useGetUserTheme();
   const { mutate } = usePatchUserTheme();
 
   useEffect(() => {
-    if (data?.theme === 'light') {
+    if (theme === 'light') {
       document.body.classList.remove('dark');
       return;
     }
     document.body.classList.add('dark');
-  }, [data]);
+  }, [theme]);
 
   const ref = useOutsideClick(() => {
     setShowTabs({ search: false, alarm: false });
@@ -57,11 +57,10 @@ export const Sidebar = () => {
     }
 
     if (item.text === '다크모드') {
-      if (data?.theme === 'dark') {
+      if (theme === 'dark') {
         mutate({ theme: 'light' });
       }
-
-      if (data?.theme === 'light') {
+      if (theme === 'light') {
         mutate({ theme: 'dark' });
       }
     }

--- a/packages/frontend/src/pages/stock-detail/TradingChart.tsx
+++ b/packages/frontend/src/pages/stock-detail/TradingChart.tsx
@@ -1,4 +1,5 @@
-import { useRef, useState } from 'react';
+import { type LogicalRange } from 'lightweight-charts';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { RadioButton } from './components/RadioButton';
 import { useChart } from './hooks/useChart';
@@ -13,18 +14,49 @@ export const TradingChart = () => {
   const { stockId } = useParams();
   const [timeunit, setTimeunit] =
     useState<StockTimeSeriesRequest['timeunit']>('day');
+  const isPending = useRef(false);
+
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const { data } = useGetStocksPriceSeries({
+  const { data, fetchNextPage, hasNextPage } = useGetStocksPriceSeries({
     stockId: stockId ?? '',
     timeunit,
   });
 
+  const allPriceData = data?.pages.flatMap((page) => page.priceDtoList) ?? [];
+  const allVolumeData = data?.pages.flatMap((page) => page.volumeDtoList) ?? [];
+
   const chart = useChart({
-    priceData: data?.priceDtoList ?? [],
-    volumeData: data?.volumeDtoList ?? [],
+    priceData: allPriceData,
+    volumeData: allVolumeData,
     containerRef,
   });
+
+  const fetchGraphData = useCallback(
+    async (logicalRange: LogicalRange | null) => {
+      if (isPending.current) return;
+      isPending.current = true;
+
+      if (logicalRange && logicalRange.from < 10 && hasNextPage) {
+        await fetchNextPage();
+      }
+
+      isPending.current = false;
+    },
+    [hasNextPage, fetchNextPage],
+  );
+
+  useEffect(() => {
+    const chartInstance = chart.current;
+    if (!chartInstance) return;
+
+    const timeScale = chartInstance.timeScale();
+    timeScale.subscribeVisibleLogicalRangeChange(fetchGraphData);
+
+    return () => {
+      timeScale.unsubscribeVisibleLogicalRangeChange(fetchGraphData);
+    };
+  }, [chart, fetchGraphData]);
 
   useChartResize({ containerRef, chart });
 


### PR DESCRIPTION
close #126 

## ✅ 작업 내용

- 그래프를 이전으로 스크롤하면 해당 시점의 데이터를 불러오도록 설정
- 스크롤 시 동일한 api 요청이 가는 문제 해결
- 무한스크롤을 구현하지 않아 차트의 확대/이동 막았던 옵션을 해제 -> 이제 확대/이동 가능합니다!

## 📸 스크린샷(FE만)

![result](https://github.com/user-attachments/assets/c83685fc-bcba-42a4-aa72-299950d4cc06)

## 📌 이슈 사항

구현하며 겪은 문제를 위키에 적어뒀습니다.

[🔖 useInfiniteQuery를 사용한 그래프 무한스크롤 구현](https://github.com/boostcampwm-2024/web17-juchumjuchum/wiki/%F0%9F%94%96-useInfiniteQuery%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%9C-%EA%B7%B8%EB%9E%98%ED%94%84-%EB%AC%B4%ED%95%9C%EC%8A%A4%ED%81%AC%EB%A1%A4-%EA%B5%AC%ED%98%84)

[🎫 사용자의 시점 변화 없는 그래프 스크롤 구현하기](https://github.com/boostcampwm-2024/web17-juchumjuchum/wiki/%F0%9F%8E%AB-%EC%82%AC%EC%9A%A9%EC%9E%90%EC%9D%98-%EC%8B%9C%EC%A0%90-%EB%B3%80%ED%99%94-%EC%97%86%EB%8A%94-%EA%B7%B8%EB%9E%98%ED%94%84-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)

[🧪 수많은 그래프 데이터 요청을 어떻게 줄일까](https://github.com/boostcampwm-2024/web17-juchumjuchum/wiki/%F0%9F%A7%AA-%EC%88%98%EB%A7%8E%EC%9D%80-%EA%B7%B8%EB%9E%98%ED%94%84-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%9A%94%EC%B2%AD%EC%9D%84-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%A4%84%EC%9D%BC%EA%B9%8C)


## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
