### PR TITLE
Feature/#324 - 새로고침 시 다크모드 깜빡임 해결

### DIFF
--- a/packages/frontend/src/components/layouts/Sidebar.tsx
+++ b/packages/frontend/src/components/layouts/Sidebar.tsx
@@ -1,13 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import logoCharacter from '/logoCharacter.png';
 import logoTitle from '/logoTitle.png';
 import { Alarm } from './alarm';
 import { MenuList } from './MenuList';
 import { Search } from './search';
-import { useGetUserTheme } from '@/apis/queries/user/useGetUserTheme';
-import { usePatchUserTheme } from '@/apis/queries/user/usePatchUserTheme';
 import { BOTTOM_MENU_ITEMS, TOP_MENU_ITEMS } from '@/constants/menuItems';
+import { ThemeContext } from '@/contexts/themeContext';
 import { useOutsideClick } from '@/hooks/useOutsideClick';
 import { type MenuSection } from '@/types/menu';
 import { cn } from '@/utils/cn';
@@ -22,16 +21,7 @@ export const Sidebar = () => {
     alarm: false,
   });
 
-  const { data: theme } = useGetUserTheme();
-  const { mutate } = usePatchUserTheme();
-
-  useEffect(() => {
-    if (theme === 'light') {
-      document.body.classList.remove('dark');
-      return;
-    }
-    document.body.classList.add('dark');
-  }, [theme]);
+  const { theme, changeTheme } = useContext(ThemeContext);
 
   const ref = useOutsideClick(() => {
     setShowTabs({ search: false, alarm: false });
@@ -47,22 +37,16 @@ export const Sidebar = () => {
     if (tabKey) {
       setShowTabs((prev) =>
         Object.keys(prev).reduce(
-          (acc, key) => ({
-            ...acc,
-            [key]: key === tabKey,
-          }),
+          (acc, key) => ({ ...acc, [key]: key === tabKey }),
           {} as Record<TabKey, boolean>,
         ),
       );
+      return;
     }
 
     if (item.text === '다크모드') {
-      if (theme === 'dark') {
-        mutate({ theme: 'light' });
-      }
-      if (theme === 'light') {
-        mutate({ theme: 'dark' });
-      }
+      const newTheme = theme === 'dark' ? 'light' : 'dark';
+      changeTheme(newTheme);
     }
   };
 

--- a/packages/frontend/src/contexts/themeContext.ts
+++ b/packages/frontend/src/contexts/themeContext.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+import { GetUserTheme } from '@/apis/queries/user';
+
+interface ThemeContextType {
+  theme: GetUserTheme['theme'];
+  changeTheme: (newTheme: GetUserTheme['theme']) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  changeTheme: () => {},
+});

--- a/packages/frontend/src/contexts/themeProvider.tsx
+++ b/packages/frontend/src/contexts/themeProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { ThemeContext } from './themeContext';
 import { useGetLoginStatus } from '@/apis/queries/auth';
@@ -21,9 +21,7 @@ export const ThemeProvider = () => {
     initialTheme as GetUserTheme['theme'],
   );
 
-  useEffect(() => {
-    document.body.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
+  document.body.classList.toggle('dark', theme === 'dark');
 
   const changeTheme = (newTheme: GetUserTheme['theme']) => {
     localStorage.setItem('theme', newTheme);

--- a/packages/frontend/src/contexts/themeProvider.tsx
+++ b/packages/frontend/src/contexts/themeProvider.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import { ThemeContext } from './themeContext';
+import { useGetLoginStatus } from '@/apis/queries/auth';
+import {
+  GetUserTheme,
+  useGetUserTheme,
+  usePatchUserTheme,
+} from '@/apis/queries/user';
+
+export const ThemeProvider = () => {
+  const { data: loginStatus } = useGetLoginStatus();
+  const { data: userTheme } = useGetUserTheme();
+  const { mutate: updateTheme } = usePatchUserTheme();
+
+  const isAuthenticated = loginStatus?.message === 'Authenticated';
+  const initialTheme = isAuthenticated
+    ? userTheme
+    : localStorage.getItem('theme');
+  const [theme, setTheme] = useState<GetUserTheme['theme']>(
+    initialTheme as GetUserTheme['theme'],
+  );
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  const changeTheme = (newTheme: GetUserTheme['theme']) => {
+    localStorage.setItem('theme', newTheme);
+    setTheme(newTheme);
+
+    if (isAuthenticated) {
+      updateTheme({ theme: newTheme });
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, changeTheme }}>
+      <Outlet />
+    </ThemeContext.Provider>
+  );
+};

--- a/packages/frontend/src/pages/my-page/StockInfo.tsx
+++ b/packages/frontend/src/pages/my-page/StockInfo.tsx
@@ -32,7 +32,7 @@ export const StockInfo = ({ loginStatus }: StockInfoProps) => {
           <article className="grid grid-cols-2 gap-5">
             {data?.userStocks.map((stock) => (
               <section
-                className="display-bold14 text-dark-gray flex cursor-pointer justify-between rounded bg-[#FAFAFA] p-10 transition-all duration-300 hover:scale-105"
+                className="display-bold14 text-dark-gray bg-extra-light-gray flex cursor-pointer justify-between rounded p-10 transition-all duration-300 hover:scale-105"
                 onClick={() => navigate(`/stocks/${stock.stockId}`)}
               >
                 <p>{stock.name}</p>

--- a/packages/frontend/src/pages/stock-detail/hooks/useChart.ts
+++ b/packages/frontend/src/pages/stock-detail/hooks/useChart.ts
@@ -1,11 +1,11 @@
 import { createChart, type IChartApi } from 'lightweight-charts';
-import { useEffect, useRef, RefObject } from 'react';
+import { useEffect, useRef, RefObject, useContext } from 'react';
 import {
   PriceSchema,
   StockTimeSeriesResponse,
   VolumeSchema,
 } from '@/apis/queries/stocks';
-import { useGetUserTheme } from '@/apis/queries/user';
+import { ThemeContext } from '@/contexts/themeContext';
 import { darkTheme, lightTheme } from '@/styles/theme';
 import {
   createCandlestickOptions,
@@ -43,7 +43,7 @@ export const useChart = ({
   const volumeSeries = useRef<ReturnType<IChartApi['addHistogramSeries']>>();
   const containerInstance = containerRef.current;
 
-  const { data: theme } = useGetUserTheme();
+  const { theme } = useContext(ThemeContext);
   const graphTheme = theme === 'light' ? lightTheme : darkTheme;
 
   useEffect(() => {

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import { Layout } from '@/components/layouts';
+import { ThemeProvider } from '@/contexts/themeProvider';
 import { Login } from '@/pages/login';
 import { MyPage } from '@/pages/my-page';
 import { StockDetail } from '@/pages/stock-detail';
@@ -7,27 +8,32 @@ import { Stocks } from '@/pages/stocks';
 
 export const router = createBrowserRouter([
   {
-    element: <Layout />,
+    element: <ThemeProvider />,
     children: [
       {
-        path: '/',
-        element: <Stocks />,
-      },
-      {
-        path: '/stocks',
-        element: <Stocks />,
-      },
-      {
-        path: 'stocks/:stockId',
-        element: <StockDetail />,
-      },
-      {
-        path: '/my-page',
-        element: <MyPage />,
-      },
-      {
-        path: '/login',
-        element: <Login />,
+        element: <Layout />,
+        children: [
+          {
+            path: '/',
+            element: <Stocks />,
+          },
+          {
+            path: '/stocks',
+            element: <Stocks />,
+          },
+          {
+            path: 'stocks/:stockId',
+            element: <StockDetail />,
+          },
+          {
+            path: '/my-page',
+            element: <MyPage />,
+          },
+          {
+            path: '/login',
+            element: <Login />,
+          },
+        ],
       },
     ],
   },

--- a/packages/frontend/src/sockets/config.ts
+++ b/packages/frontend/src/sockets/config.ts
@@ -22,4 +22,5 @@ export const socketChat = ({ stockId, pageSize = 20 }: SocketChatType) => {
 export const socketStock = io(`${URL}/api/stock/realtime`, {
   transports: ['websocket'],
   reconnectionDelayMax: 10000,
+  forceNew: true,
 });

--- a/packages/frontend/src/sockets/config.ts
+++ b/packages/frontend/src/sockets/config.ts
@@ -22,5 +22,4 @@ export const socketChat = ({ stockId, pageSize = 20 }: SocketChatType) => {
 export const socketStock = io(`${URL}/api/stock/realtime`, {
   transports: ['websocket'],
   reconnectionDelayMax: 10000,
-  forceNew: true,
 });


### PR DESCRIPTION
close #324 

## ✅ 작업 내용

- 다크모드 상태에서 새로고침 할 때, 라이트모드가 잠깐 보였다가 다크모드가 보이는 문제를 해결 
- 비로그인 상태에서도 다크모드 적용
  - 서버에서 다크모드 상태를 저장하고 있기 때문에, 이전에는 이 상황에 맞춰서 다크모드를 구현했었음
  - 그러다보니 로그인을 안한 사용자는 다크모드를 적용/유지하지 못하는 문제 발생
  - 비로그인 상태에서는 로컬스토리지에 저장
- 테마 변경은 context api로 전역에서 관리
  - 사이드바와 그래프에서 테마 상태를 공유 받아야함
  -  테마 상태는 서버(로그인 상태)와 로컬스토리지(비로그인 상태)에서 관리되기 때문에 이를 하나의 일관된 인터페이스로 제공하기 위해 context api 도입 (물론 로그인 상태에서도 로컬스토리지에 추가 관리중임. 로그아웃을 했을 때는 상태가 사라지기 때문)

## 📌 이슈 사항

[🌚 다크모드에서 새로고침 시 라이트모드가 잠깐 보이는 문제](https://github.com/boostcampwm-2024/web17-juchumjuchum/wiki/%F0%9F%8C%9A-%EB%8B%A4%ED%81%AC%EB%AA%A8%EB%93%9C%EC%97%90%EC%84%9C-%EC%83%88%EB%A1%9C%EA%B3%A0%EC%B9%A8-%EC%8B%9C-%EB%9D%BC%EC%9D%B4%ED%8A%B8%EB%AA%A8%EB%93%9C%EA%B0%80-%EC%9E%A0%EA%B9%90-%EB%B3%B4%EC%9D%B4%EB%8A%94-%EB%AC%B8%EC%A0%9C)

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
