### PR TITLE
Feature/#341 분봉 리팩토링 및 장 시간대에 분봉 받아오기, alarm 한번만 작동

### DIFF
--- a/packages/backend/src/alarm/alarm.service.ts
+++ b/packages/backend/src/alarm/alarm.service.ts
@@ -110,6 +110,8 @@ export class AlarmService {
 
     for (const subscription of subscriptions) {
       await this.pushService.sendPushNotification(subscription, payload);
+      //한번만 보내고 삭제하게 처리.
+      this.alarmRepository.delete(alarm.id);
     }
   }
 }

--- a/packages/backend/src/alarm/alarm.subscriber.ts
+++ b/packages/backend/src/alarm/alarm.subscriber.ts
@@ -28,13 +28,13 @@ export class AlarmSubscriber
   }
 
   isValidAlarm(alarm: Alarm, entity: StockMinutely) {
-    if (alarm.alarmDate && alarm.alarmDate > entity.createdAt) {
+    if (alarm.alarmDate && alarm.alarmDate >= entity.createdAt) {
       return false;
     } else {
-      if (alarm.targetPrice && alarm.targetPrice >= entity.open) {
+      if (alarm.targetPrice && alarm.targetPrice <= entity.open) {
         return true;
       }
-      if (alarm.targetVolume && alarm.targetVolume >= entity.volume) {
+      if (alarm.targetVolume && alarm.targetVolume <= entity.volume) {
         return true;
       }
       return false;
@@ -48,7 +48,6 @@ export class AlarmSubscriber
         where: { stock: { id: stockMinutely.stock.id } },
         relations: ['user', 'stock'],
       });
-
       const alarms = rawAlarms.filter((val) =>
         this.isValidAlarm(val, stockMinutely),
       );

--- a/packages/backend/src/alarm/dto/subscribe.request.ts
+++ b/packages/backend/src/alarm/dto/subscribe.request.ts
@@ -1,10 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-//import { User } from '@/user/domain/user.entity';
 
 export class SubscriptionData {
-  //@ApiProperty({ type: () => User, description: '유저 아이디' })
-  //user: User;
-
   @ApiProperty({
     type: 'string',
     description: '엔드 포인트 설정',

--- a/packages/backend/src/scraper/openapi/api/openapiMinuteData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiMinuteData.api.ts
@@ -97,16 +97,10 @@ export class OpenapiMinuteData {
       this.convertResToMinuteData(stockId, val, time),
     );
     if (stockPeriod[0]) {
-      this.datasource.manager
-        .createQueryBuilder()
-        .insert()
-        .into(this.entity)
-        .values(stockPeriod[0])
-        .orUpdate(
-          ['id', 'close', 'low', 'high', 'open', 'volume', 'created_at'],
-          ['stock_id', 'start_time'],
-        )
-        .execute();
+      this.datasource.manager.upsert(this.entity, stockPeriod[0], [
+        'stock.id',
+        'startTime',
+      ]);
     }
   }
 

--- a/packages/backend/src/scraper/openapi/api/openapiMinuteData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiMinuteData.api.ts
@@ -31,9 +31,7 @@ export class OpenapiMinuteData {
     private readonly datasource: DataSource,
     private readonly openapiQueue: OpenapiQueue,
     @Inject('winston') private readonly logger: Logger,
-  ) {
-    this.getStockMinuteData();
-  }
+  ) {}
 
   @Cron(`* 9-15 * * 1-5`)
   async getStockMinuteData() {
@@ -129,8 +127,7 @@ export class OpenapiMinuteData {
 
   private isMarketOpenTime(time: string) {
     const numberTime = parseInt(time);
-    // 이거 바꿔놓음
-    return numberTime >= 90000 && numberTime <= 203000;
+    return numberTime >= 90000 && numberTime <= 153000;
   }
 
   private getUpdateStockQuery(

--- a/packages/backend/src/scraper/openapi/api/openapiMinuteData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiMinuteData.api.ts
@@ -1,49 +1,93 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
 import { DataSource } from 'typeorm';
-import { Logger } from 'winston';
-import { openApiConfig } from '../config/openapi.config';
-
+import {
+  Json,
+  OpenapiQueue,
+  OpenapiQueueNodeValue,
+} from '../queue/openapi.queue';
 import {
   isMinuteData,
   MinuteData,
   UpdateStockQuery,
 } from '../type/openapiMinuteData.type';
 import { TR_IDS } from '../type/openapiUtil.type';
-import { getCurrentTime, getOpenApi } from '../util/openapiUtil.api';
-import { OpenapiTokenApi } from './openapiToken.api';
+import { getCurrentTime } from '../util/openapiUtil.api';
+import { Alarm } from '@/alarm/domain/alarm.entity';
 import { Stock } from '@/stock/domain/stock.entity';
 import { StockData, StockMinutely } from '@/stock/domain/stockData.entity';
 
-const STOCK_CUT = 4;
-
 @Injectable()
 export class OpenapiMinuteData {
-  private stock: Stock[][] = [];
   private readonly entity = StockMinutely;
   private readonly url: string =
     '/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice';
-  private readonly intervals: number = 130;
-  private flip: number = 0;
   constructor(
     private readonly datasource: DataSource,
-    private readonly openApiToken: OpenapiTokenApi,
-    @Inject('winston') private readonly logger: Logger,
+    private readonly openapiQueue: OpenapiQueue,
   ) {
-    //this.getStockData();
+    this.getStockMinuteData();
   }
 
-  async getStockData() {
+  @Cron(`* 9-15 * * 1-5`)
+  async getStockMinuteData() {
     if (process.env.NODE_ENV !== 'production') return;
-    const stock = await this.datasource.manager.findBy(Stock, {
-      isTrading: true,
-    });
-    const stockSize = Math.ceil(stock.length / STOCK_CUT);
-    let i = 0;
-    this.stock = [];
-    while (i < STOCK_CUT) {
-      this.stock.push(stock.slice(i * stockSize, (i + 1) * stockSize));
-      i++;
+    const alarms = await this.datasource.manager
+      .getRepository(Alarm)
+      .createQueryBuilder('alarm')
+      .leftJoin('alarm.stock', 'stock')
+      .select('stock.id', 'stockId')
+      .addSelect('COUNT(alarm.id)', 'alarmCount')
+      .groupBy('stock.id')
+      .orderBy('alarmCount', 'DESC')
+      .execute();
+    console.log(alarms);
+    for (const alarm of alarms) {
+      const time = getCurrentTime();
+      const query = this.getUpdateStockQuery(alarm.stockId, time);
+      const node: OpenapiQueueNodeValue = {
+        url: this.url,
+        query,
+        trId: TR_IDS.MINUTE_DATA,
+        callback: this.getStockMinuteDataCallback(alarm.stockId, time),
+      };
+      this.openapiQueue.enqueue(node);
     }
+  }
+
+  getStockMinuteDataCallback(stockId: string, time: string) {
+    return async (data: Json) => {
+      let output;
+      if (data.output2) output = data.output2;
+      if (output && output[0] && isMinuteData(output[0])) {
+        console.log(output);
+        this.saveMinuteData(stockId, output as MinuteData[], time);
+      }
+    };
+  }
+
+  private async saveMinuteData(
+    stockId: string,
+    item: MinuteData[],
+    time: string,
+  ) {
+    if (!this.isMarketOpenTime(time)) return;
+    const stockPeriod = item.map((val) =>
+      this.convertResToMinuteData(stockId, val, time),
+    );
+    for (const stock of stockPeriod) {
+      this.datasource.manager
+        .createQueryBuilder()
+        .insert()
+        .into(this.entity)
+        .values(stock)
+        .orUpdate(
+          ['id', 'close', 'low', 'high', 'open', 'volume', 'created_at'],
+          ['stock_id', 'start_time'],
+        )
+        .execute();
+    }
+    //this.datasource.manager.save(this.entity, stockPeriod);
   }
 
   private convertResToMinuteData(
@@ -71,70 +115,8 @@ export class OpenapiMinuteData {
 
   private isMarketOpenTime(time: string) {
     const numberTime = parseInt(time);
-    return numberTime >= 90000 && numberTime <= 153000;
-  }
-
-  private async saveMinuteData(
-    stockId: string,
-    item: MinuteData[],
-    time: string,
-  ) {
-    const manager = this.datasource.manager;
-    if (!this.isMarketOpenTime(time)) return;
-    const stockPeriod = item.map((val) =>
-      this.convertResToMinuteData(stockId, val, time),
-    );
-    manager.save(this.entity, stockPeriod);
-  }
-
-  private async getMinuteDataInterval(
-    stockId: string,
-    time: string,
-    config: typeof openApiConfig,
-  ) {
-    const query = this.getUpdateStockQuery(stockId, time);
-    try {
-      const response = await getOpenApi(
-        this.url,
-        config,
-        query,
-        TR_IDS.MINUTE_DATA,
-      );
-      let output;
-      if (response.output2) output = response.output2;
-      if (output && output[0] && isMinuteData(output[0])) {
-        this.saveMinuteData(stockId, output, time);
-      }
-    } catch (error) {
-      this.logger.warn(error);
-    }
-  }
-
-  private async getMinuteDataChunk(
-    chunk: Stock[],
-    config: typeof openApiConfig,
-  ) {
-    const time = getCurrentTime();
-    let interval = 0;
-    for await (const stock of chunk) {
-      setTimeout(
-        () => this.getMinuteDataInterval(stock.id!, time, config),
-        interval,
-      );
-      interval += this.intervals;
-    }
-  }
-
-  async getMinuteData() {
-    if (process.env.NODE_ENV !== 'production') return;
-    const configCount = (await this.openApiToken.configs()).length;
-    const stock = this.stock[this.flip % STOCK_CUT];
-    this.flip++;
-    const chunkSize = Math.ceil(stock.length / configCount);
-    for (let i = 0; i < configCount; i++) {
-      const chunk = stock.slice(i * chunkSize, (i + 1) * chunkSize);
-      this.getMinuteDataChunk(chunk, (await this.openApiToken.configs())[i]);
-    }
+    // 이거 바꿔놓음
+    return numberTime >= 90000 && numberTime <= 183000;
   }
 
   private getUpdateStockQuery(

--- a/packages/backend/src/scraper/openapi/liveData.service.ts
+++ b/packages/backend/src/scraper/openapi/liveData.service.ts
@@ -75,6 +75,7 @@ export class LiveData {
           stockId,
           '1',
         );
+        this.logger.info(`${idx} : ${message}`);
         this.websocketClient[idx].subscribe(message);
         return;
       }
@@ -99,7 +100,7 @@ export class LiveData {
         stockId,
         '2',
       );
-
+      this.logger.info(`${idx} : ${message}`);
       this.websocketClient[idx].unsubscribe(message);
     }
   }

--- a/packages/backend/src/scraper/openapi/liveData.service.ts
+++ b/packages/backend/src/scraper/openapi/liveData.service.ts
@@ -130,7 +130,7 @@ export class LiveData {
           return;
         }
         const liveData = this.openapiLiveData.convertLiveData(message);
-        await this.openapiLiveData.saveLiveData(liveData[0])
+        await this.openapiLiveData.saveLiveData(liveData[0]);
       } catch (error) {
         this.logger.warn(error);
       }

--- a/packages/backend/src/scraper/openapi/type/openapiMinuteData.type.ts
+++ b/packages/backend/src/scraper/openapi/type/openapiMinuteData.type.ts
@@ -1,14 +1,67 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export type MinuteData = {
+export type MinuteDataOutput1 = {
+  prdy_vrss: string;
+  prdy_vrss_sign: string;
+  prdy_ctrt: string;
+  stck_prdy_clpr: string;
+  acml_vol: string;
+  acml_tr_pbmn: string;
+  hts_kor_isnm: string;
+  stck_prpr: string;
+};
+
+export type MinuteDataOutput2 = {
   stck_bsop_date: string;
   stck_cntg_hour: string;
+  acml_tr_pbmn: string;
   stck_prpr: string;
   stck_oprc: string;
   stck_hgpr: string;
   stck_lwpr: string;
   cntg_vol: string;
+};
+
+export type MinuteData = {
+  stck_bsop_date: string;
+  stck_cntg_hour: string;
   acml_tr_pbmn: string;
+  acml_vol: string;
+  stck_prpr: string;
+  stck_oprc: string;
+  stck_hgpr: string;
+  stck_lwpr: string;
+  cntg_vol: string;
+};
+
+export const isMinuteDataOutput1 = (data: any): data is MinuteDataOutput1 => {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    typeof data.prdy_vrss === 'string' &&
+    typeof data.prdy_vrss_sign === 'string' &&
+    typeof data.prdy_ctrt === 'string' &&
+    typeof data.stck_prdy_clpr === 'string' &&
+    typeof data.acml_vol === 'string' &&
+    typeof data.acml_tr_pbmn === 'string' &&
+    typeof data.hts_kor_isnm === 'string' &&
+    typeof data.stck_prpr === 'string'
+  );
+};
+
+export const isMinuteDataOutput2 = (data: any): data is MinuteDataOutput2 => {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    typeof data.stck_bsop_date === 'string' &&
+    typeof data.stck_cntg_hour === 'string' &&
+    typeof data.acml_tr_pbmn === 'string' &&
+    typeof data.stck_prpr === 'string' &&
+    typeof data.stck_oprc === 'string' &&
+    typeof data.stck_hgpr === 'string' &&
+    typeof data.stck_lwpr === 'string' &&
+    typeof data.cntg_vol === 'string'
+  );
 };
 
 export type UpdateStockQuery = {
@@ -17,19 +70,4 @@ export type UpdateStockQuery = {
   fid_input_iscd: string;
   fid_input_hour_1: string;
   fid_pw_data_incu_yn: 'Y' | 'N';
-};
-
-export const isMinuteData = (data: any) => {
-  return (
-    data &&
-    typeof data === 'object' &&
-    typeof data.stck_bsop_date === 'string' &&
-    typeof data.stck_cntg_hour === 'string' &&
-    typeof data.stck_prpr === 'string' &&
-    typeof data.stck_oprc === 'string' &&
-    typeof data.stck_hgpr === 'string' &&
-    typeof data.stck_lwpr === 'string' &&
-    typeof data.cntg_vol === 'string' &&
-    typeof data.acml_tr_pbmn === 'string'
-  );
 };


### PR DESCRIPTION
close #341

## ✅ 작업 내용

- [x] 분봉 우선순위 큐를 이용해 리팩토링
- [x] 장시간대에 분봉 받아오기
- [x] alarm 한번만 작동

## 📌 이슈 사항

- 현재 유저가 로그아웃을 했을 때에도 주춤 사이트에 접속해 있는 상태이고, 같은 디바이스를 사용한다면 무조건 알림이 가는 상태입니다

## ✍ 궁금한 점

- 알림을 한번만 보내게 설정을 바꿨는 데, 이게 맞는 지 궁금합니다! 알림 확인 버튼을 눌렀을 때 더이상 안 보내고, 취소 버튼 누르면 다시 보내게도 만들 수 있긴 한데... 뭔가 이상해서요.

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
