### PR TITLE
Feature/#339 - 채팅 좋아요순 정렬 적용, 채팅 줄바꿈/엔터 전송 적용

### DIFF
--- a/packages/frontend/src/apis/queries/chat/index.ts
+++ b/packages/frontend/src/apis/queries/chat/index.ts
@@ -1,2 +1,3 @@
 export * from './schema';
 export * from './usePostChatLike';
+export * from './useGetChatList';

--- a/packages/frontend/src/apis/queries/chat/schema.ts
+++ b/packages/frontend/src/apis/queries/chat/schema.ts
@@ -20,6 +20,7 @@ export const GetChatListRequestSchema = z.object({
   stockId: z.string(),
   latestChatId: z.number().optional(),
   pageSize: z.number().optional(),
+  order: z.enum(['latest', 'like']).optional(),
 });
 
 export type GetChatListRequest = z.infer<typeof GetChatListRequestSchema>;

--- a/packages/frontend/src/apis/queries/chat/useGetChatList.ts
+++ b/packages/frontend/src/apis/queries/chat/useGetChatList.ts
@@ -27,7 +27,7 @@ export const useGetChatList = ({
   order,
 }: GetChatListRequest) => {
   return useInfiniteQuery({
-    queryKey: ['chatList', stockId, pageSize, latestChatId, order],
+    queryKey: ['chatList', stockId, order],
     queryFn: ({ pageParam }) =>
       getChatList({
         stockId,
@@ -46,7 +46,6 @@ export const useGetChatList = ({
       pages: [...data.pages].flatMap((page) => page.chats),
       pageParams: [...data.pageParams],
     }),
-    enabled: !!latestChatId,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/packages/frontend/src/apis/queries/chat/useGetChatList.ts
+++ b/packages/frontend/src/apis/queries/chat/useGetChatList.ts
@@ -27,11 +27,26 @@ export const useGetChatList = ({
   order,
 }: GetChatListRequest) => {
   return useInfiniteQuery({
-    queryKey: ['chatList', stockId, latestChatId, pageSize, order],
-    queryFn: () => getChatList({ stockId, latestChatId, pageSize, order }),
-    getNextPageParam: (data) => (data.hasMore ? true : null),
-    initialPageParam: false,
-    staleTime: 60 * 1000 * 5,
+    queryKey: ['chatList', stockId, pageSize, latestChatId, order],
+    queryFn: ({ pageParam }) =>
+      getChatList({
+        stockId,
+        latestChatId: pageParam?.latestChatId,
+        pageSize,
+        order,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore
+        ? {
+            latestChatId: lastPage.chats[lastPage.chats.length - 1].id,
+          }
+        : undefined,
+    initialPageParam: { latestChatId },
+    select: (data) => ({
+      pages: [...data.pages].flatMap((page) => page.chats),
+      pageParams: [...data.pageParams],
+    }),
     enabled: !!latestChatId,
+    staleTime: 1000 * 60 * 5,
   });
 };

--- a/packages/frontend/src/apis/queries/chat/useGetChatList.ts
+++ b/packages/frontend/src/apis/queries/chat/useGetChatList.ts
@@ -3,7 +3,12 @@ import { GetChatListRequest } from './schema';
 import { get } from '@/apis/utils/get';
 import { ChatDataResponse, ChatDataResponseSchema } from '@/sockets/schema';
 
-const getChatList = ({ stockId, latestChatId, pageSize }: GetChatListRequest) =>
+const getChatList = ({
+  stockId,
+  latestChatId,
+  pageSize,
+  order,
+}: GetChatListRequest) =>
   get<ChatDataResponse>({
     schema: ChatDataResponseSchema,
     url: '/api/chat',
@@ -11,6 +16,7 @@ const getChatList = ({ stockId, latestChatId, pageSize }: GetChatListRequest) =>
       stockId,
       latestChatId,
       pageSize,
+      order,
     },
   });
 
@@ -18,10 +24,11 @@ export const useGetChatList = ({
   stockId,
   latestChatId,
   pageSize,
+  order,
 }: GetChatListRequest) => {
   return useInfiniteQuery({
-    queryKey: ['chatList', stockId, latestChatId, pageSize],
-    queryFn: () => getChatList({ stockId, latestChatId, pageSize }),
+    queryKey: ['chatList', stockId, latestChatId, pageSize, order],
+    queryFn: () => getChatList({ stockId, latestChatId, pageSize, order }),
     getNextPageParam: (data) => (data.hasMore ? true : null),
     initialPageParam: false,
     staleTime: 60 * 1000 * 5,

--- a/packages/frontend/src/constants/metricDetail.ts
+++ b/packages/frontend/src/constants/metricDetail.ts
@@ -74,7 +74,7 @@ export const METRICS_DATA = ({
       metrics: [
         {
           ...METRIC_DETAILS.enterpriseValue.marketCap,
-          value: `${marketCap?.toLocaleString()}원`,
+          value: `${marketCap?.toLocaleString()}억원`,
         },
         {
           ...METRIC_DETAILS.enterpriseValue.per,

--- a/packages/frontend/src/contexts/themeProvider.tsx
+++ b/packages/frontend/src/contexts/themeProvider.tsx
@@ -16,7 +16,7 @@ export const ThemeProvider = () => {
   const isAuthenticated = loginStatus?.message === 'Authenticated';
   const initialTheme = isAuthenticated
     ? userTheme
-    : localStorage.getItem('theme');
+    : localStorage.getItem('juchumTheme');
   const [theme, setTheme] = useState<GetUserTheme['theme']>(
     initialTheme as GetUserTheme['theme'],
   );
@@ -24,7 +24,7 @@ export const ThemeProvider = () => {
   document.body.classList.toggle('dark', theme === 'dark');
 
   const changeTheme = (newTheme: GetUserTheme['theme']) => {
-    localStorage.setItem('theme', newTheme);
+    localStorage.setItem('juchumTheme', newTheme);
     setTheme(newTheme);
 
     if (isAuthenticated) {

--- a/packages/frontend/src/contexts/themeProvider.tsx
+++ b/packages/frontend/src/contexts/themeProvider.tsx
@@ -16,7 +16,7 @@ export const ThemeProvider = () => {
   const isAuthenticated = loginStatus?.message === 'Authenticated';
   const initialTheme = isAuthenticated
     ? userTheme
-    : localStorage.getItem('juchumTheme');
+    : localStorage.getItem('theme');
   const [theme, setTheme] = useState<GetUserTheme['theme']>(
     initialTheme as GetUserTheme['theme'],
   );
@@ -24,7 +24,7 @@ export const ThemeProvider = () => {
   document.body.classList.toggle('dark', theme === 'dark');
 
   const changeTheme = (newTheme: GetUserTheme['theme']) => {
-    localStorage.setItem('juchumTheme', newTheme);
+    localStorage.setItem('theme', newTheme);
     setTheme(newTheme);
 
     if (isAuthenticated) {

--- a/packages/frontend/src/hooks/useInfiniteScroll.ts
+++ b/packages/frontend/src/hooks/useInfiniteScroll.ts
@@ -2,19 +2,15 @@ import { useEffect, useRef } from 'react';
 
 interface InfiniteScrollProps {
   onIntersect: () => void;
-  hasMore: boolean;
 }
 
-export const useInfiniteScroll = ({
-  onIntersect,
-  hasMore,
-}: InfiniteScrollProps) => {
+export const useInfiniteScroll = ({ onIntersect }: InfiniteScrollProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && hasMore) {
+        if (entries[0].isIntersecting) {
           onIntersect();
         }
       },
@@ -28,10 +24,10 @@ export const useInfiniteScroll = ({
 
     return () => {
       if (instance) {
-        observer.unobserve(instance);
+        observer.disconnect();
       }
     };
-  }, [onIntersect, hasMore]);
+  }, [onIntersect]);
 
   return { ref };
 };

--- a/packages/frontend/src/hooks/useInfiniteScroll.ts
+++ b/packages/frontend/src/hooks/useInfiniteScroll.ts
@@ -2,19 +2,23 @@ import { useEffect, useRef } from 'react';
 
 interface InfiniteScrollProps {
   onIntersect: () => void;
+  hasNextPage: boolean;
 }
 
-export const useInfiniteScroll = ({ onIntersect }: InfiniteScrollProps) => {
+export const useInfiniteScroll = ({
+  onIntersect,
+  hasNextPage,
+}: InfiniteScrollProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting) {
+        if (entries[0].isIntersecting && hasNextPage) {
           onIntersect();
         }
       },
-      { threshold: 0.3 },
+      { threshold: 0.5 },
     );
     const instance = ref.current;
 
@@ -27,7 +31,7 @@ export const useInfiniteScroll = ({ onIntersect }: InfiniteScrollProps) => {
         observer.disconnect();
       }
     };
-  }, [onIntersect]);
+  }, [onIntersect, hasNextPage]);
 
   return { ref };
 };

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -108,7 +108,7 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
 
   useEffect(() => {
     if (status === 'success') {
-      setChatData(data.pages.flat());
+      setChatData(data.pages);
     }
   }, [data, status]);
 

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -99,7 +99,8 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
     if (!isOwnerStock) return alert('주식 소유자만 가능합니다.');
     clickLike({ chatId });
   };
-  const { fetchNextPage, data, status, isFetchingNextPage } = useGetChatList({
+
+  const { fetchNextPage, data, status, isFetching } = useGetChatList({
     stockId,
     order,
   });
@@ -197,7 +198,7 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
         ) : (
           <p className="text-center">채팅이 없어요.</p>
         )}
-        {isFetchingNextPage ? <Loader className="w-44" /> : <div ref={ref} />}
+        {isFetching ? <Loader className="w-44" /> : <div ref={ref} />}
       </section>
     </article>
   );

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -100,10 +100,11 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
     clickLike({ chatId });
   };
 
-  const { fetchNextPage, data, status, isFetching } = useGetChatList({
-    stockId,
-    order,
-  });
+  const { fetchNextPage, data, status, isFetching, hasNextPage } =
+    useGetChatList({
+      stockId,
+      order,
+    });
 
   useEffect(() => {
     if (status === 'success') {
@@ -119,7 +120,10 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
     }
   };
 
-  const { ref } = useInfiniteScroll({ onIntersect: fetchMoreChats });
+  const { ref } = useInfiniteScroll({
+    onIntersect: fetchMoreChats,
+    hasNextPage,
+  });
 
   const isWriter = (chat: ChatData) => {
     if (!nickname || !subName) {

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -99,17 +99,16 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
     if (!isOwnerStock) return alert('주식 소유자만 가능합니다.');
     clickLike({ chatId });
   };
-
   const { fetchNextPage, data, status, isFetchingNextPage } = useGetChatList({
     stockId,
     order,
   });
 
   useEffect(() => {
-    if (data) {
-      setChatData(data.pages);
+    if (status === 'success') {
+      setChatData(data.pages.flat());
     }
-  }, [data]);
+  }, [data, status]);
 
   const fetchMoreChats = () => {
     fetchNextPage();

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -30,11 +30,14 @@ interface ChatPanelProps {
   isOwnerStock: boolean;
 }
 
+type OrderType = 'latest' | 'like';
+
 export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
   const { stockId = '' } = useParams();
   const [chatData, setChatData] = useState<ChatData[]>([]);
   const [latestChatId, setLatestChatId] = useState<number>();
   const [hasMore, setHasMore] = useState(false);
+  const [order, setOrder] = useState<OrderType>('latest');
 
   const { mutate } = usePostChatLike();
   const { message, nickname, subName } = loginStatus;
@@ -117,6 +120,7 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
   const { fetchNextPage, data, status, isFetchingNextPage } = useGetChatList({
     stockId,
     latestChatId,
+    order,
   });
 
   const fetchMoreChats = () => {
@@ -137,6 +141,13 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
   const checkWriter = (chat: ChatData) =>
     chat.nickname === nickname && chat.subName === subName;
 
+  const handleOrderType = () => {
+    setOrder((prev) => {
+      if (prev === 'latest') return 'like';
+      return 'latest';
+    });
+  };
+
   return (
     <article className="flex min-w-80 flex-col gap-5 rounded-md bg-white p-7 shadow">
       <h2 className="display-bold20 text-center font-bold">채팅</h2>
@@ -147,9 +158,14 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
       />
       <div className="border-light-gray display-medium12 text-dark-gray flex items-center justify-between gap-1 border-b-2 pb-2">
         <span>{isConnected ? '🟢 접속 중' : '❌ 연결 끊김'}</span>
-        <div className="flex items-center gap-2">
-          <p>최신순</p>
-          <DownArrow className="cursor-pointer" />
+        <div className="flex items-center gap-2" onClick={handleOrderType}>
+          <p>{order === 'latest' ? '최신순' : '좋아요순'}</p>
+          <DownArrow
+            className={cn(
+              'cursor-pointer',
+              order === 'latest' ? 'rotate-0' : 'rotate-180',
+            )}
+          />
         </div>
       </div>
       <section

--- a/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/ChatPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { TextArea } from './components';
 import { ChatMessage } from './components/ChatMessage';
+import { useChatOrder } from './hooks/useChatOrder';
 import { GetLoginStatus } from '@/apis/queries/auth/schema';
 import { usePostChatLike } from '@/apis/queries/chat';
 import { useGetChatList } from '@/apis/queries/chat/useGetChatList';
@@ -15,7 +16,6 @@ import {
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { socketChat } from '@/sockets/config';
 import {
-  ChatDataResponseSchema,
   ChatDataSchema,
   ChatLikeSchema,
   type ChatLikeResponse,
@@ -23,6 +23,7 @@ import {
   type ChatDataResponse,
 } from '@/sockets/schema';
 import { useWebsocket } from '@/sockets/useWebsocket';
+import { checkChatWriter } from '@/utils/checkChatWriter';
 import { cn } from '@/utils/cn';
 
 interface ChatPanelProps {
@@ -30,20 +31,18 @@ interface ChatPanelProps {
   isOwnerStock: boolean;
 }
 
-type OrderType = 'latest' | 'like';
+const INITIAL_VISIBLE_CHATS = 3;
 
 export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
-  const { stockId = '' } = useParams();
-  const [chatData, setChatData] = useState<ChatData[]>([]);
-  const [latestChatId, setLatestChatId] = useState<number>();
-  const [hasMore, setHasMore] = useState(false);
-  const [order, setOrder] = useState<OrderType>('latest');
-
-  const { mutate } = usePostChatLike();
   const { message, nickname, subName } = loginStatus;
 
-  const socket = useMemo(() => socketChat({ stockId }), [stockId]);
+  const { stockId = '' } = useParams();
+  const [chatData, setChatData] = useState<ChatData[]>([]);
 
+  const { mutate: clickLike } = usePostChatLike();
+  const { order, handleOrderType } = useChatOrder();
+
+  const socket = useMemo(() => socketChat({ stockId }), [stockId]);
   const { isConnected } = useWebsocket(socket);
 
   const userStatus: ChatStatus = useMemo(() => {
@@ -54,27 +53,14 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
     return isOwnerStock ? UserStatus.OWNERSHIP : UserStatus.NOT_OWNERSHIP;
   }, [message, isOwnerStock]);
 
-  const handleChat = useCallback(
-    (message: ChatDataResponse | Partial<ChatData>) => {
-      if ('chats' in message && message.chats) {
-        const validatedChatData = ChatDataResponseSchema.parse(message);
-        if (validatedChatData) {
-          setChatData((prev) => [...message.chats, ...prev]);
-          setHasMore(message.hasMore);
-        }
-        return;
-      }
+  const handleChat = useCallback((message: ChatDataResponse | ChatData) => {
+    if ('chats' in message) return;
 
-      const validatedSingleChat = ChatDataSchema.partial().parse(message);
-      if (validatedSingleChat) {
-        setChatData((prev) => [
-          { ...validatedSingleChat } as ChatData,
-          ...prev,
-        ]);
-      }
-    },
-    [],
-  );
+    const validatedSingleChat = ChatDataSchema.parse(message);
+    if (validatedSingleChat) {
+      setChatData((prev) => [{ ...validatedSingleChat } as ChatData, ...prev]);
+    }
+  }, []);
 
   const handleSendMessage = (message: string) => {
     if (!message) return;
@@ -110,42 +96,37 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
   }, [stockId, socket, handleChat]);
 
   const handleLikeClick = (chatId: number) => {
-    if (isOwnerStock) {
-      mutate({ chatId });
-      return;
-    }
-    alert('주식 소유자만 가능합니다.');
+    if (!isOwnerStock) return alert('주식 소유자만 가능합니다.');
+    clickLike({ chatId });
   };
 
   const { fetchNextPage, data, status, isFetchingNextPage } = useGetChatList({
     stockId,
-    latestChatId,
     order,
   });
 
+  useEffect(() => {
+    if (data) {
+      setChatData(data.pages);
+    }
+  }, [data]);
+
   const fetchMoreChats = () => {
-    setLatestChatId(chatData[chatData.length - 1]?.id);
     fetchNextPage();
 
     if (status === 'success') {
-      setChatData((prev) => [...prev, ...data.pages[0].chats]);
-      setHasMore(data.pages[0].hasMore);
+      setChatData(data.pages);
     }
   };
 
-  const { ref } = useInfiniteScroll({
-    onIntersect: fetchMoreChats,
-    hasMore,
-  });
+  const { ref } = useInfiniteScroll({ onIntersect: fetchMoreChats });
 
-  const checkWriter = (chat: ChatData) =>
-    chat.nickname === nickname && chat.subName === subName;
+  const isWriter = (chat: ChatData) => {
+    if (!nickname || !subName) {
+      return false;
+    }
 
-  const handleOrderType = () => {
-    setOrder((prev) => {
-      if (prev === 'latest') return 'like';
-      return 'latest';
-    });
+    return checkChatWriter({ chat, nickname, subName });
   };
 
   return (
@@ -176,7 +157,7 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
       >
         {chatData.length ? (
           <>
-            {chatData.slice(0, 3).map((chat) => (
+            {chatData.slice(0, INITIAL_VISIBLE_CHATS).map((chat) => (
               <ChatMessage
                 key={chat.id}
                 name={chat.nickname}
@@ -185,11 +166,11 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
                 liked={chat.liked}
                 subName={chat.subName}
                 createdAt={chat.createdAt}
-                writer={checkWriter(chat)}
+                writer={isWriter(chat)}
                 onClick={() => handleLikeClick(chat.id)}
               />
             ))}
-            {chatData.slice(3).map((chat, index) => (
+            {chatData.slice(INITIAL_VISIBLE_CHATS).map((chat, index) => (
               <div className="relative" key={`${chat.id}-${index}`}>
                 {!isOwnerStock && (
                   <div className="absolute inset-0 flex items-center justify-center text-center backdrop-blur-sm">
@@ -208,7 +189,7 @@ export const ChatPanel = ({ loginStatus, isOwnerStock }: ChatPanelProps) => {
                   liked={chat.liked}
                   subName={chat.subName}
                   createdAt={chat.createdAt}
-                  writer={checkWriter(chat)}
+                  writer={isWriter(chat)}
                   onClick={() => handleLikeClick(chat.id)}
                 />
               </div>

--- a/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
@@ -45,7 +45,7 @@ export const ChatMessage = ({
       <div className="flex items-center gap-2">
         <p
           className={cn(
-            'display-bold14 w-full whitespace-pre rounded p-2 py-3',
+            'display-bold14 w-full whitespace-pre-wrap rounded p-2 py-3',
             writer ? 'bg-light-yellow' : 'bg-extra-light-gray',
           )}
         >

--- a/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/ChatMessage.tsx
@@ -45,7 +45,7 @@ export const ChatMessage = ({
       <div className="flex items-center gap-2">
         <p
           className={cn(
-            'display-bold14 w-full rounded p-2 py-3',
+            'display-bold14 w-full whitespace-pre rounded p-2 py-3',
             writer ? 'bg-light-yellow' : 'bg-extra-light-gray',
           )}
         >

--- a/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
+++ b/packages/frontend/src/pages/stock-detail/components/TextArea.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, type KeyboardEvent, useState } from 'react';
 import Send from '@/assets/send.svg?react';
 import { cn } from '@/utils/cn';
 
@@ -12,11 +12,19 @@ export const TextArea = ({ disabled, onSend, placeholder }: TextAreaProps) => {
   const [chatText, setChatText] = useState('');
   const [inputCount, setInputCount] = useState(0);
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: FormEvent | KeyboardEvent) => {
     event.preventDefault();
+    if (chatText.trim() === '') return;
     onSend(chatText);
     setChatText('');
     setInputCount(0);
+  };
+
+  const handleEnterPress = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      handleSubmit(event);
+    }
   };
 
   return (
@@ -36,6 +44,7 @@ export const TextArea = ({ disabled, onSend, placeholder }: TextAreaProps) => {
             setChatText(e.target.value);
             setInputCount(e.target.value.length);
           }}
+          onKeyDown={handleEnterPress}
         />
         <button
           className={cn(

--- a/packages/frontend/src/pages/stock-detail/hooks/useChatOrder.ts
+++ b/packages/frontend/src/pages/stock-detail/hooks/useChatOrder.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+
+type OrderType = 'latest' | 'like';
+
+export const useChatOrder = () => {
+  const [order, setOrder] = useState<OrderType>('latest');
+  const handleOrderType = () =>
+    setOrder((prev) => (prev === 'latest' ? 'like' : 'latest'));
+
+  return { order, handleOrderType };
+};

--- a/packages/frontend/src/utils/checkChatWriter.ts
+++ b/packages/frontend/src/utils/checkChatWriter.ts
@@ -1,0 +1,14 @@
+import { ChatData } from '@/sockets/schema';
+
+interface CheckChatWriterProps {
+  chat: ChatData;
+  nickname: string;
+  subName: string;
+}
+
+export const checkChatWriter = ({
+  chat,
+  nickname,
+  subName,
+}: CheckChatWriterProps) =>
+  chat.nickname === nickname && chat.subName === subName;


### PR DESCRIPTION
close #339 

## ✅ 작업 내용

- 채팅 좋아요순 정렬 적용
- 채팅 줄바꿈 적용
- 채팅 엔터시 전송
- 시가총액 억 단위 추가

## 📸 스크린샷(FE만)

https://github.com/user-attachments/assets/43fc991f-34fd-4a13-bec2-b3f4ecf11dee


## 📌 이슈 사항

- 관련 내용 [위키](https://github.com/boostcampwm-2024/web17-juchumjuchum/wiki/%F0%9F%91%8A-%EC%9B%B9%EC%86%8C%EC%BC%93%EC%9D%98-%EC%B1%84%ED%8C%85-%EB%8D%B0%EC%9D%B4%ED%84%B0%EC%99%80-REST-API%EC%9D%98-%EC%B1%84%ED%8C%85-%EB%8D%B0%EC%9D%B4%ED%84%B0%EB%A5%BC-%ED%95%A8%EA%BB%98-%EA%B4%80%EB%A6%AC%ED%95%98%EA%B8%B0)에 적어뒀습니다!

- 채팅 관련 리팩토링이 필요합니다. 

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
