### PR TITLE
Feature/#355 - 검색어 빈 값 요청 처리, 초기 로딩 시 그래프만 다크모드인 문제 수정

### DIFF
--- a/packages/frontend/src/components/layouts/search/Search.tsx
+++ b/packages/frontend/src/components/layouts/search/Search.tsx
@@ -15,6 +15,7 @@ export const Search = ({ className }: SearchProps) => {
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (!stockName) return;
     refetch();
   };
 

--- a/packages/frontend/src/pages/stock-detail/hooks/useChart.ts
+++ b/packages/frontend/src/pages/stock-detail/hooks/useChart.ts
@@ -44,7 +44,11 @@ export const useChart = ({
   const containerInstance = containerRef.current;
 
   const { theme } = useContext(ThemeContext);
-  const graphTheme = theme === 'light' ? lightTheme : darkTheme;
+  const graphTheme = theme
+    ? theme === 'light'
+      ? lightTheme
+      : darkTheme
+    : lightTheme;
 
   useEffect(() => {
     if (!containerInstance) return;


### PR DESCRIPTION
close #355 #354 

## ✅ 작업 내용

- 검색어가 빈 값 일 경우 요청하지 못하도록 수정
- 초기 로딩 시 그래프만 다크모드로 설정되는 문제 수정

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
