### PR TITLE
Feature/#367 - 주, 월, 년 봉 데이터를 새벽 업데이트 이후에서 16시까지 갱신하지 않도록 변경

### DIFF
--- a/packages/backend/src/scraper/openapi/api/openapiLiveData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiLiveData.api.ts
@@ -5,7 +5,7 @@ import { openApiConfig } from '../config/openapi.config';
 import { isOpenapiLiveData } from '../type/openapiLiveData.type';
 import { TR_IDS } from '../type/openapiUtil.type';
 import { getOpenApi } from '../util/openapiUtil.api';
-import { Json } from '@/scraper/openapi/queue/openapi.queue';
+import { Json, OpenapiQueue } from '@/scraper/openapi/queue/openapi.queue';
 import { Stock } from '@/stock/domain/stock.entity';
 import { StockLiveData } from '@/stock/domain/stockLiveData.entity';
 
@@ -15,6 +15,7 @@ export class OpenapiLiveData {
     '/uapi/domestic-stock/v1/quotations/inquire-ccnl';
   constructor(
     private readonly datasource: DataSource,
+    private readonly openapiQueue: OpenapiQueue,
     @Inject('winston') private readonly logger: Logger,
   ) {}
 
@@ -74,6 +75,16 @@ export class OpenapiLiveData {
       stockData.push(stockLiveData);
     });
     return stockData;
+  }
+
+  insertLiveDataRequest(stockId: string) {
+    const query = this.makeLiveDataQuery(stockId);
+    this.openapiQueue.enqueue({
+      url: this.url,
+      query,
+      trId: TR_IDS.LIVE_DATA,
+      callback: this.getLiveDataSaveCallback(stockId),
+    });
   }
 
   async connectLiveData(stockId: string, config: typeof openApiConfig) {

--- a/packages/backend/src/utils/date.ts
+++ b/packages/backend/src/utils/date.ts
@@ -10,3 +10,11 @@ export function isTodayWeekend() {
   const day = today.getDay();
   return day === 0 || day === 6;
 }
+
+export function getToday() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const day = now.getDate();
+  return new Date(year, month, day);
+}


### PR DESCRIPTION
close #367 

## ✅ 작업 내용
- 주, 월, 년 데이터 갱신 제한
- 웹소켓 연결시 실시간 데이터 요청을 큐로 제어

## 📌 이슈 사항
- 분 단위를 제외하고 새벽에 업데이트 이후에 16시까지 갱신하지 않도록 했습니다.
  - 그 이유는 마지막 시점의 데이터를 실시간 데이터 조합해서 출력하게 되는데
  - 구매량의 경우 장이 열릴 때 갱신되면, 정확한 구매량을 보여줄 수 없는 문제가 있습니다.
  -  다시 장이 마감되면 업데이트가 진행되도록 했습니다.
- 하지만 로직이 정확하지 않을 수 있어, 오늘 장이 열릴 때 확인해봐야 될거 같아요

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
